### PR TITLE
Add Buffer type field as PhantomData.

### DIFF
--- a/src/command_queue.rs
+++ b/src/command_queue.rs
@@ -16,6 +16,7 @@ pub use cl3::command_queue::*;
 
 use super::device::Device;
 use super::event::Event;
+use super::memory::Buffer;
 
 use cl3::types::{
     cl_bool, cl_command_queue, cl_command_queue_properties, cl_context, cl_device_id, cl_event,
@@ -136,7 +137,7 @@ impl CommandQueue {
 
     pub fn enqueue_read_buffer<T>(
         &self,
-        buffer: cl_mem,
+        buffer: &Buffer<T>,
         blocking_read: cl_bool,
         offset: size_t,
         data: &mut [T],
@@ -144,7 +145,7 @@ impl CommandQueue {
     ) -> Result<Event, cl_int> {
         let event = enqueue_read_buffer(
             self.queue,
-            buffer,
+            buffer.get(),
             blocking_read,
             offset,
             (data.len() * mem::size_of::<T>()) as size_t,
@@ -159,9 +160,9 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
-    pub fn enqueue_read_buffer_rect(
+    pub fn enqueue_read_buffer_rect<T>(
         &self,
-        buffer: cl_mem,
+        buffer: &Buffer<T>,
         blocking_read: cl_bool,
         buffer_origin: *const size_t,
         host_origin: *const size_t,
@@ -175,7 +176,7 @@ impl CommandQueue {
     ) -> Result<Event, cl_int> {
         let event = enqueue_read_buffer_rect(
             self.queue,
-            buffer,
+            buffer.get(),
             blocking_read,
             buffer_origin,
             host_origin,
@@ -197,7 +198,7 @@ impl CommandQueue {
 
     pub fn enqueue_write_buffer<T>(
         &self,
-        buffer: cl_mem,
+        buffer: &Buffer<T>,
         blocking_write: cl_bool,
         offset: size_t,
         data: &[T],
@@ -205,7 +206,7 @@ impl CommandQueue {
     ) -> Result<Event, cl_int> {
         let event = enqueue_write_buffer(
             self.queue,
-            buffer,
+            buffer.get(),
             blocking_write,
             offset,
             (data.len() * mem::size_of::<T>()) as size_t,
@@ -220,9 +221,9 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
-    pub fn enqueue_write_buffer_rect(
+    pub fn enqueue_write_buffer_rect<T>(
         &self,
-        buffer: cl_mem,
+        buffer: &Buffer<T>,
         blocking_write: cl_bool,
         buffer_origin: *const size_t,
         host_origin: *const size_t,
@@ -236,7 +237,7 @@ impl CommandQueue {
     ) -> Result<Event, cl_int> {
         let event = enqueue_write_buffer_rect(
             self.queue,
-            buffer,
+            buffer.get(),
             blocking_write,
             buffer_origin,
             host_origin,
@@ -258,7 +259,7 @@ impl CommandQueue {
 
     pub fn enqueue_fill_buffer<T>(
         &self,
-        buffer: cl_mem,
+        buffer: &Buffer<T>,
         pattern: &[T],
         offset: size_t,
         size: size_t,
@@ -266,7 +267,7 @@ impl CommandQueue {
     ) -> Result<Event, cl_int> {
         let event = enqueue_fill_buffer(
             self.queue,
-            buffer,
+            buffer.get(),
             pattern.as_ptr() as cl_mem,
             pattern.len() * mem::size_of::<T>(),
             offset,
@@ -281,10 +282,10 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
-    pub fn enqueue_copy_buffer(
+    pub fn enqueue_copy_buffer<T>(
         &self,
-        src_buffer: cl_mem,
-        dst_buffer: cl_mem,
+        src_buffer: &Buffer<T>,
+        dst_buffer: &Buffer<T>,
         src_offset: size_t,
         dst_offset: size_t,
         size: size_t,
@@ -292,8 +293,8 @@ impl CommandQueue {
     ) -> Result<Event, cl_int> {
         let event = enqueue_copy_buffer(
             self.queue,
-            src_buffer,
-            dst_buffer,
+            src_buffer.get(),
+            dst_buffer.get(),
             src_offset,
             dst_offset,
             size,
@@ -306,10 +307,10 @@ impl CommandQueue {
         )?;
         Ok(Event::new(event))
     }
-    pub fn enqueue_copy_buffer_rect(
+    pub fn enqueue_copy_buffer_rect<T>(
         &self,
-        src_buffer: cl_mem,
-        dst_buffer: cl_mem,
+        src_buffer: &Buffer<T>,
+        dst_buffer: &Buffer<T>,
         src_origin: *const size_t,
         dst_origin: *const size_t,
         region: *const size_t,
@@ -321,8 +322,8 @@ impl CommandQueue {
     ) -> Result<Event, cl_int> {
         let event = enqueue_copy_buffer_rect(
             self.queue,
-            src_buffer,
-            dst_buffer,
+            src_buffer.get(),
+            dst_buffer.get(),
             src_origin,
             dst_origin,
             region,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -100,11 +100,11 @@ fn test_opencl_1_2_example() {
     }
 
     // Create OpenCL device buffers
-    let x = Buffer::create::<cl_float>(&context, CL_MEM_WRITE_ONLY, ARRAY_SIZE, ptr::null_mut())
+    let x = Buffer::<cl_float>::create(&context, CL_MEM_WRITE_ONLY, ARRAY_SIZE, ptr::null_mut())
         .unwrap();
-    let y = Buffer::create::<cl_float>(&context, CL_MEM_WRITE_ONLY, ARRAY_SIZE, ptr::null_mut())
+    let y = Buffer::<cl_float>::create(&context, CL_MEM_WRITE_ONLY, ARRAY_SIZE, ptr::null_mut())
         .unwrap();
-    let z = Buffer::create::<cl_float>(&context, CL_MEM_READ_ONLY, ARRAY_SIZE, ptr::null_mut())
+    let z = Buffer::<cl_float>::create(&context, CL_MEM_READ_ONLY, ARRAY_SIZE, ptr::null_mut())
         .unwrap();
 
     let queue = context.default_queue();
@@ -113,12 +113,12 @@ fn test_opencl_1_2_example() {
 
     // Blocking write
     let _x_write_event = queue
-        .enqueue_write_buffer(x.get(), CL_TRUE, 0, &ones, &events)
+        .enqueue_write_buffer(&x, CL_TRUE, 0, &ones, &events)
         .unwrap();
 
     // Non-blocking write, wait for y_write_event
     let y_write_event = queue
-        .enqueue_write_buffer(y.get(), CL_FALSE, 0, &sums, &events)
+        .enqueue_write_buffer(&y, CL_FALSE, 0, &sums, &events)
         .unwrap();
 
     // Convert to CString for get_kernel function
@@ -147,7 +147,7 @@ fn test_opencl_1_2_example() {
         // after the kernel event completes.
         let mut results: [cl_float; ARRAY_SIZE] = [0.0; ARRAY_SIZE];
         let _event = queue
-            .enqueue_read_buffer(z.get(), CL_FALSE, 0, &mut results, &events)
+            .enqueue_read_buffer(&z, CL_FALSE, 0, &mut results, &events)
             .unwrap();
         events.clear();
 


### PR DESCRIPTION
Add PhantomData type to Buffer indicating the type of data the Buffer points to. There is an example in [Unused type parameter](https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters) section of the PhantomData marker docs.

The sole purpose of the type field is to help Rust compiler's type checking, preventing accidentally reading to result array of another type or writing data with different type using CommandQueue's `enqueue_` methods. The field is hidden in docs becaue it has size of zero bytes i.e. it doesn't exist at runtime. This hiding in the docs has been the choice e.g. in [euclid](https://doc.servo.org/euclid/index.html) math tools crate.

If data with different type needs to be written or read into result array of another type however, the type parameter can be explicitly cast with the `cast()` method, which essentially creates a clone of the Buffer with the new type. Although other methods for achieving the same would exist, such as casting the data to correct type before writing or after reading to result array.