### PR TITLE
Remove Buffer cast method

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -184,10 +184,6 @@ impl<T> Buffer<T> {
     pub fn get(&self) -> cl_mem {
         self.buffer
     }
-
-    pub fn cast<NewT>(&self) -> Buffer<NewT> {
-        Buffer::new(self.buffer)
-    }
 }
 
 /// An OpenCL image.  

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -90,7 +90,7 @@ pub fn get_mem_properties(memobj: cl_mem) -> Result<Vec<cl_ulong>, cl_int> {
 pub struct Buffer<T> {
     buffer: cl_mem,
     #[doc(hidden)]
-    pub _type: PhantomData<T>,
+    _type: PhantomData<T>,
 }
 
 impl<T> Drop for Buffer<T> {


### PR DESCRIPTION
Buffer objects should actually never be cloned because it will result in double free when the original and typecasted Buffer objects are dropped. Pardon for this bug introduced in my previous pull request.

A better way is to cast the data of another type to correct type before writing to a Buffer, and when reading, doing the type cast after reading from the Buffer to result array. This should also be more explicit in the code.