### PR TITLE
Implement Clone for CommandQueue

### DIFF
--- a/src/command_queue.rs
+++ b/src/command_queue.rs
@@ -35,6 +35,13 @@ pub struct CommandQueue {
     max_work_item_dimensions: cl_uint,
 }
 
+impl Clone for CommandQueue {
+    fn clone(&self) -> CommandQueue {
+        retain_command_queue(self.queue).unwrap();
+        CommandQueue::new(self.queue, self.max_work_item_dimensions)
+    }
+}
+
 impl Drop for CommandQueue {
     fn drop(&mut self) {
         release_command_queue(self.queue).unwrap();


### PR DESCRIPTION
I usually use `.except()` instead of `.unwrap()` in my code, but I wanted to match the current style.