### PR TITLE
Make types Send and Sync where applicable

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -353,6 +353,9 @@ impl Context {
     }
 }
 
+// `Context` contains `Kernel`s, hence it's `Send` but not `Sync`
+unsafe impl Send for Context {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/device.rs
+++ b/src/device.rs
@@ -58,6 +58,9 @@ impl SubDevice {
     }
 }
 
+unsafe impl Send for SubDevice {}
+unsafe impl Sync for SubDevice {}
+
 /// An OpenCL device id and methods to query it.  
 /// The query methods calls clGetDeviceInfo with the relevant param_name, see:
 /// [Device Queries](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#device-queries-table).
@@ -608,6 +611,9 @@ impl Device {
         }
     }
 }
+
+unsafe impl Send for Device {}
+unsafe impl Sync for Device {}
 
 #[cfg(test)]
 mod tests {

--- a/src/event.rs
+++ b/src/event.rs
@@ -107,3 +107,6 @@ impl Event {
         )
     }
 }
+
+unsafe impl Send for Event {}
+unsafe impl Sync for Event {}

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -255,6 +255,10 @@ impl Kernel {
     }
 }
 
+// Some kernel operations are not safe from being accessed from multiple threads. Hence `Kernel`
+// only implements `Send` but not `Sync`. See: https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_multiple_host_threads
+unsafe impl Send for Kernel {}
+
 /// A struct that implements the [builder pattern](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html)
 /// to simplify setting up [Kernel] arguments and the [NDRange](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_mapping_work_items_onto_an_ndrange)
 /// when enqueueing a [Kernel] on a [CommandQueue].

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -186,6 +186,9 @@ impl<T> Buffer<T> {
     }
 }
 
+unsafe impl<T: Send> Send for Buffer<T> {}
+unsafe impl<T: Sync> Sync for Buffer<T> {}
+
 /// An OpenCL image.  
 /// Has methods to return information from calls to clGetImageInfo with the
 /// appropriate parameters.  
@@ -327,6 +330,9 @@ impl Image {
     }
 }
 
+unsafe impl Send for Image {}
+unsafe impl Sync for Image {}
+
 /// An OpenCL sampler.  
 /// Has methods to return information from calls to clGetSamplerInfo with the
 /// appropriate parameters.  
@@ -373,6 +379,9 @@ impl Sampler {
         self.sampler
     }
 }
+
+unsafe impl Send for Sampler {}
+unsafe impl Sync for Sampler {}
 
 /// An OpenCL pipe.  
 /// Has methods to return information from calls to clGetPipeInfo with the
@@ -422,3 +431,6 @@ impl Pipe {
         Ok(value.to_vec_intptr())
     }
 }
+
+unsafe impl Send for Pipe {}
+unsafe impl Sync for Pipe {}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -141,6 +141,9 @@ impl Platform {
     }
 }
 
+unsafe impl Send for Platform {}
+unsafe impl Sync for Platform {}
+
 /// Get the available OpenCL platforms.  
 /// # Examples
 /// ```

--- a/src/program.rs
+++ b/src/program.rs
@@ -325,3 +325,6 @@ impl Program {
         .to_size())
     }
 }
+
+unsafe impl Send for Program {}
+unsafe impl Sync for Program {}

--- a/src/svm.rs
+++ b/src/svm.rs
@@ -132,6 +132,10 @@ impl<'a, T> Drop for SvmRawVec<'a, T> {
     }
 }
 
+// It is not `Sync` as `SvmRawVec` contains a `Context`, which isn't `Sync` itself due to
+// containing `Kernel`s
+unsafe impl<T: Send> Send for SvmRawVec<'_, T> {}
+
 /// An OpenCL Shared Virtual Memory (SVM) vector.  
 /// It has the lifetime of the [Context] that it was constructed from.  
 /// Note: T cannot be a "zero sized type" (ZST).
@@ -309,6 +313,9 @@ impl<'a, T: Debug> fmt::Debug for SvmVec<'a, T> {
         fmt::Debug::fmt(&**self, f)
     }
 }
+
+// It is not `Sync` as `SvmVec` contains a `SvmRawVec`, which isn't `Sync` itself
+unsafe impl<T: Send> Send for SvmVec<'_, T> {}
 
 struct RawValIter<T> {
     start: *const T,


### PR DESCRIPTION
All operations in OpenCL, except a few on kernels are thread-safe, see
https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_multiple_host_threads

Hence it's safe to implement `Send` and `Sync` for all of them, except for
`Kernel`. There only `Send` is implemented as it is still safe to move it
between threads, only concurrent access is a problem.

Currently the shared virtual memory types don't implement `Sync`, although
they theoretically could. The reason is that they currently have in internal
reference to the `Context` type, which contains `Kernel`s, which are not
`Sync`. This could be changed by only storing the `cl_context` instead of
a full `Context` reference within the shared virtual memory types.

Please note that I'm new to OpenCL so please review this PR carefully, I might
have missed things.