### PR TITLE
Implement Clone for most of the types

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -40,6 +40,13 @@ pub struct SubDevice {
     id: cl_device_id,
 }
 
+impl Clone for SubDevice {
+    fn clone(&self) -> SubDevice {
+        retain_device(self.id).unwrap();
+        SubDevice::new(self.id)
+    }
+}
+
 impl Drop for SubDevice {
     fn drop(&mut self) {
         release_device(self.id).unwrap();
@@ -61,6 +68,9 @@ impl SubDevice {
 /// An OpenCL device id and methods to query it.  
 /// The query methods calls clGetDeviceInfo with the relevant param_name, see:
 /// [Device Queries](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#device-queries-table).
+// Root devices don't need to be reference counted for cloning, see:
+// https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#clRetainDevice
+#[derive(Clone, Copy)]
 pub struct Device {
     id: cl_device_id,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -25,6 +25,13 @@ pub struct Event {
     event: cl_event,
 }
 
+impl Clone for Event {
+    fn clone(&self) -> Event {
+        retain_event(self.event).unwrap();
+        Event::new(self.event)
+    }
+}
+
 impl Drop for Event {
     fn drop(&mut self) {
         release_event(self.event).unwrap();

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -35,6 +35,16 @@ pub struct Kernel {
     num_args: cl_uint,
 }
 
+impl Clone for Kernel {
+    fn clone(&self) -> Kernel {
+        retain_kernel(self.kernel).unwrap();
+        Kernel {
+            kernel: self.kernel,
+            num_args: self.num_args,
+        }
+    }
+}
+
 impl Drop for Kernel {
     fn drop(&mut self) {
         release_kernel(self.kernel).unwrap();
@@ -62,10 +72,13 @@ impl Kernel {
     /// Clone an OpenCL kernel object.  
     /// CL_VERSION_2_1 see: [Copying Kernel Objects](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#_copying_kernel_objects)
     ///
+    /// This method clones the actual kernel object. Its internal reference count will be reset.
+    /// The `Clone` implementation shares the instance and just increases the reference count.
+    ///
     /// returns a Result containing the new Kernel
     /// or the error code from the OpenCL C API function.
     #[cfg(feature = "CL_VERSION_2_1")]
-    pub fn clone(&self) -> Result<Kernel, cl_int> {
+    pub fn data_clone(&self) -> Result<Kernel, cl_int> {
         let kernel = clone_kernel(self.kernel)?;
         Ok(Kernel {
             kernel,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -93,6 +93,13 @@ pub struct Buffer<T> {
     _type: PhantomData<T>,
 }
 
+impl<T> Clone for Buffer<T> {
+    fn clone(&self) -> Buffer<T> {
+        memory::retain_mem_object(self.buffer).unwrap();
+        Buffer::new(self.buffer)
+    }
+}
+
 impl<T> Drop for Buffer<T> {
     fn drop(&mut self) {
         memory::release_mem_object(self.buffer).unwrap();
@@ -192,6 +199,13 @@ impl<T> Buffer<T> {
 /// Implements the Drop trait to call release_mem_object when the object is dropped.
 pub struct Image {
     image: cl_mem,
+}
+
+impl Clone for Image {
+    fn clone(&self) -> Image {
+        memory::retain_mem_object(self.image).unwrap();
+        Image::new(self.image)
+    }
 }
 
 impl Drop for Image {
@@ -335,6 +349,13 @@ pub struct Sampler {
     sampler: cl_sampler,
 }
 
+impl Clone for Sampler {
+    fn clone(&self) -> Sampler {
+        sampler::retain_sampler(self.sampler).unwrap();
+        Sampler::new(self.sampler)
+    }
+}
+
 impl Drop for Sampler {
     fn drop(&mut self) {
         sampler::release_sampler(self.sampler).unwrap();
@@ -380,6 +401,13 @@ impl Sampler {
 /// Implements the Drop trait to call release_mem_object when the object is dropped.
 pub struct Pipe {
     pipe: cl_mem,
+}
+
+impl Clone for Pipe {
+    fn clone(&self) -> Pipe {
+        memory::retain_mem_object(self.pipe).unwrap();
+        Pipe::new(self.pipe)
+    }
 }
 
 impl Drop for Pipe {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -23,6 +23,7 @@ use std::ffi::CString;
 /// An OpenCL platform id and methods to query it.  
 /// The query methods calls clGetPlatformInfo with the relevant param_name, see:
 /// [Platform Queries](https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_API.html#platform-queries-table).
+#[derive(Clone, Copy)]
 pub struct Platform {
     id: cl_platform_id,
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -27,6 +27,13 @@ pub struct Program {
     program: cl_program,
 }
 
+impl Clone for Program {
+    fn clone(&self) -> Program {
+        retain_program(self.program).unwrap();
+        Program::new(self.program)
+    }
+}
+
 impl Drop for Program {
     fn drop(&mut self) {
         release_program(self.program).unwrap();


### PR DESCRIPTION
`Clone` is not implemented for `Context` as it is more than a thin wrapper
around `cl_context`, which would need manual reference counting in order to
free resources properly when dropping the last instance. As it makes sense
to put more thought into the current idea of `Context`, I decided to not
implement `Clone` for now.

The `clone()` method of `Kernel` was renamed to `data_clone()` so that it
can be distinguished from the `Clone` implementation, that does only add
another shared reference. It was done in order to keep the `Clone` API
symmetric across all OpenCL types.

Types that don't need reference counting, `Device` and `Platform` also
implement `Copy`.

I'm not sure about the kernel clone being named `data_clone()`, perhaps there
is a better way? I also don't really understand (due to my lack of OpenCL
knowledge) why you would clone it that way instead of just having a reference.