### PR TITLE
Implement Send for some of the types

### DIFF
--- a/src/command_queue.rs
+++ b/src/command_queue.rs
@@ -58,6 +58,8 @@ impl Drop for CommandQueue {
     }
 }
 
+unsafe impl Send for CommandQueue {}
+
 impl CommandQueue {
     fn new(queue: cl_command_queue, max_work_item_dimensions: cl_uint) -> CommandQueue {
         CommandQueue {

--- a/src/context.rs
+++ b/src/context.rs
@@ -87,6 +87,8 @@ impl Drop for Context {
     }
 }
 
+unsafe impl Send for Context {}
+
 impl Context {
     fn new(context: cl_context, devices: &[cl_device_id]) -> Context {
         Context {

--- a/src/device.rs
+++ b/src/device.rs
@@ -48,6 +48,8 @@ impl Drop for SubDevice {
     }
 }
 
+unsafe impl Send for SubDevice {}
+
 impl SubDevice {
     pub fn new(id: cl_device_id) -> SubDevice {
         SubDevice { id }

--- a/src/event.rs
+++ b/src/event.rs
@@ -32,6 +32,8 @@ impl Drop for Event {
     }
 }
 
+unsafe impl Send for Event {}
+
 impl Event {
     /// Create an Event from an OpenCL cl_event.
     ///

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -56,6 +56,8 @@ impl Drop for Kernel {
     }
 }
 
+unsafe impl Send for Kernel {}
+
 impl Kernel {
     /// Create a Kernel from an OpenCL cl_kernel.
     ///

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -135,6 +135,8 @@ impl<T> Drop for Buffer<T> {
     }
 }
 
+unsafe impl<T: Send> Send for Buffer<T> {}
+
 impl<T> Buffer<T> {
     pub fn new(buffer: cl_mem) -> Buffer<T> {
         Buffer {
@@ -286,6 +288,8 @@ impl Drop for Image {
         memory::release_mem_object(self.get()).expect("Error: clReleaseMemObject");
     }
 }
+
+unsafe impl Send for Image {}
 
 impl Image {
     pub fn new(image: cl_mem) -> Image {
@@ -662,6 +666,8 @@ impl Drop for Sampler {
         sampler::release_sampler(self.sampler).expect("Error: clReleaseSampler");
     }
 }
+
+unsafe impl Send for Sampler {}
 
 impl Sampler {
     pub fn new(sampler: cl_sampler) -> Sampler {

--- a/src/svm.rs
+++ b/src/svm.rs
@@ -35,6 +35,8 @@ struct SvmRawVec<'a, T> {
     fine_grain_buffer: bool,
 }
 
+unsafe impl<'a, T: Send> Send for SvmRawVec<'a, T> {}
+
 impl<'a, T> SvmRawVec<'a, T> {
     fn new(context: &'a Context, svm_capabilities: cl_device_svm_capabilities) -> Self {
         assert!(0 < mem::size_of::<T>(), "No Zero Sized Types!");
@@ -314,6 +316,8 @@ struct RawValIter<T> {
     start: *const T,
     end: *const T,
 }
+
+unsafe impl<T: Send> Send for RawValIter<T> {}
 
 impl<T> RawValIter<T> {
     unsafe fn new(slice: &[T]) -> Self {


### PR DESCRIPTION
This way it's possible to move the execution off a main thread.

Closes #15.