### PR TITLE
Export sizes of UUID and LUID

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 pub use cl3::device::*;
-pub use cl3::ffi::cl_ext::cl_amd_device_topology;
+pub use cl3::ffi::cl_ext::{cl_amd_device_topology, CL_LUID_SIZE_KHR, CL_UUID_SIZE_KHR};
 
 use super::Result;
 use cl3::types::{


### PR DESCRIPTION
The `uuid_khr()`, `driver_uuid_khr()` and `luid_khr()` calls return
vectors of unsigned chars. Though they are actually fixed sized
arrays [1]. Sometimes it's useful to know their size at compile-time,
hence the constants `CL_UUID_SIZE_KHR` and `CL_LUID_SIZE_KHR`
containing the sizes of the UUIDs and LUIDs are exported.

[1]: https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#_additions_to_chapter_4_of_the_opencl_3_0_api_specification

Closes #18.