### PR TITLE
Implement CL_VERSION_* features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,5 @@ default = ["CL_VERSION_1_2", "CL_VERSION_2_0"]
 
 [dependencies]
 libc = "0.2"
-cl3 = "0.4.1"
+#cl3 = "0.4.1"
+cl3 = { git = "https://github.com/vmx/cl3", branch = "features-standard", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ default = ["CL_VERSION_1_2", "CL_VERSION_2_0"]
 [dependencies]
 libc = "0.2"
 #cl3 = "0.4.1"
-cl3 = { git = "https://github.com/vmx/cl3", branch = "features-standard", default-features = false }
+cl3 = { git = "https://github.com/kenba/cl3", branch = "develop", default-features = false }

--- a/src/command_queue.rs
+++ b/src/command_queue.rs
@@ -34,13 +34,11 @@ use cl3::ext;
 #[allow(unused_imports)]
 use cl3::ffi::cl_ext::cl_queue_properties_khr;
 use cl3::gl;
-#[cfg(any(feature = "CL_VERSION_1_2", feature = "CL_VERSION_2_1"))]
-use cl3::types::cl_mem_migration_flags;
-#[cfg(feature = "CL_VERSION_2_0")]
-use cl3::types::cl_queue_properties;
+#[allow(unused_imports)]
 use cl3::types::{
     cl_bool, cl_command_queue, cl_command_queue_properties, cl_context, cl_device_id, cl_event,
-    cl_kernel, cl_map_flags, cl_mem, cl_uint, cl_ulong,
+    cl_kernel, cl_map_flags, cl_mem, cl_mem_migration_flags, cl_queue_properties, cl_uint,
+    cl_ulong,
 };
 use libc::{c_void, size_t};
 use std::mem;
@@ -1255,12 +1253,12 @@ impl CommandQueue {
         Ok(get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_PROPERTIES)?.to_ulong())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn size(&self) -> Result<cl_uint> {
         Ok(get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_SIZE)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_1")]
+    /// CL_VERSION_2_1
     pub fn device_default(&self) -> Result<cl_device_id> {
         Ok(
             get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_DEVICE_DEFAULT)?.to_ptr()
@@ -1268,7 +1266,7 @@ impl CommandQueue {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn properties_array(&self) -> Result<Vec<cl_ulong>> {
         Ok(
             get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_PROPERTIES_ARRAY)?
@@ -1284,7 +1282,6 @@ mod tests {
     use crate::device::Device;
     use crate::platform::get_platforms;
     use cl3::device::CL_DEVICE_TYPE_GPU;
-    #[cfg(feature = "CL_VERSION_2_1")]
     use libc::intptr_t;
 
     #[test]
@@ -1324,19 +1321,19 @@ mod tests {
         println!("queue.properties(): {:X}", value);
         // assert_eq!(2, value);
 
-        #[cfg(feature = "CL_VERSION_2_0")]
+        // CL_VERSION_2_0 value
         match queue.size() {
             Ok(value) => println!("queue.size(): {:?}", value),
             Err(e) => println!("OpenCL error, queue.size(): {}", e),
         }
 
-        #[cfg(feature = "CL_VERSION_2_1")]
+        // CL_VERSION_2_1 value
         match queue.device_default() {
             Ok(value) => println!("queue.device_default(): {:X}", value as intptr_t),
             Err(e) => println!("OpenCL error, queue.device_default(): {}", e),
         }
 
-        #[cfg(feature = "CL_VERSION_3_0")]
+        // CL_VERSION_3_0 value
         match queue.properties_array() {
             Ok(value) => println!("queue.properties_array(): {:?}", value),
             Err(e) => println!("OpenCL error, queue.properties_array(): {}", e),

--- a/src/command_queue.rs
+++ b/src/command_queue.rs
@@ -34,10 +34,13 @@ use cl3::ext;
 #[allow(unused_imports)]
 use cl3::ffi::cl_ext::cl_queue_properties_khr;
 use cl3::gl;
+#[cfg(any(feature = "CL_VERSION_1_2", feature = "CL_VERSION_2_1"))]
+use cl3::types::cl_mem_migration_flags;
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl3::types::cl_queue_properties;
 use cl3::types::{
     cl_bool, cl_command_queue, cl_command_queue_properties, cl_context, cl_device_id, cl_event,
-    cl_kernel, cl_map_flags, cl_mem, cl_mem_migration_flags, cl_queue_properties, cl_uint,
-    cl_ulong,
+    cl_kernel, cl_map_flags, cl_mem, cl_uint, cl_ulong,
 };
 use libc::{c_void, size_t};
 use std::mem;
@@ -112,6 +115,7 @@ impl CommandQueue {
     ///
     /// returns a Result containing the new CommandQueue
     /// or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn create_with_properties(
         context: &Context,
         device_id: cl_device_id,
@@ -293,6 +297,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn enqueue_fill_buffer<T>(
         &self,
         buffer: &mut Buffer<T>,
@@ -437,6 +442,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn enqueue_fill_image(
         &self,
         image: &mut Image,
@@ -619,6 +625,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn enqueue_migrate_mem_object(
         &self,
         num_mem_objects: cl_uint,
@@ -690,6 +697,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn enqueue_task(&self, kernel: cl_kernel, event_wait_list: &[cl_event]) -> Result<Event> {
         let event = enqueue_task(
             self.queue,
@@ -734,6 +742,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn enqueue_marker_with_wait_list(&self, event_wait_list: &[cl_event]) -> Result<Event> {
         let event = enqueue_marker_with_wait_list(
             self.queue,
@@ -747,6 +756,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn enqueue_barrier_with_wait_list(&self, event_wait_list: &[cl_event]) -> Result<Event> {
         let event = enqueue_barrier_with_wait_list(
             self.queue,
@@ -760,6 +770,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn enqueue_svm_free(
         &self,
         svm_pointers: &[*const c_void],
@@ -790,6 +801,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn enqueue_svm_mem_cpy(
         &self,
         blocking_copy: cl_bool,
@@ -814,6 +826,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn enqueue_svm_mem_fill<T>(
         &self,
         svm_ptr: *mut c_void,
@@ -837,6 +850,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn enqueue_svm_map<T>(
         &self,
         blocking_map: cl_bool,
@@ -860,6 +874,7 @@ impl CommandQueue {
         Ok(Event::new(event))
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn enqueue_svm_unmap<T>(&self, svm: &[T], event_wait_list: &[cl_event]) -> Result<Event> {
         let event = enqueue_svm_unmap(
             self.queue,
@@ -1240,11 +1255,12 @@ impl CommandQueue {
         Ok(get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_PROPERTIES)?.to_ulong())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn size(&self) -> Result<cl_uint> {
         Ok(get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_SIZE)?.to_uint())
     }
 
-    // CL_VERSION_2_1
+    #[cfg(feature = "CL_VERSION_2_1")]
     pub fn device_default(&self) -> Result<cl_device_id> {
         Ok(
             get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_DEVICE_DEFAULT)?.to_ptr()
@@ -1252,7 +1268,7 @@ impl CommandQueue {
         )
     }
 
-    // CL_VERSION_3_0
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn properties_array(&self) -> Result<Vec<cl_ulong>> {
         Ok(
             get_command_queue_info(self.queue, CommandQueueInfo::CL_QUEUE_PROPERTIES_ARRAY)?
@@ -1268,6 +1284,7 @@ mod tests {
     use crate::device::Device;
     use crate::platform::get_platforms;
     use cl3::device::CL_DEVICE_TYPE_GPU;
+    #[cfg(feature = "CL_VERSION_2_1")]
     use libc::intptr_t;
 
     #[test]
@@ -1307,19 +1324,19 @@ mod tests {
         println!("queue.properties(): {:X}", value);
         // assert_eq!(2, value);
 
-        // CL_VERSION_2_0 value
+        #[cfg(feature = "CL_VERSION_2_0")]
         match queue.size() {
             Ok(value) => println!("queue.size(): {:?}", value),
             Err(e) => println!("OpenCL error, queue.size(): {}", e),
         }
 
-        // CL_VERSION_2_1 value
+        #[cfg(feature = "CL_VERSION_2_1")]
         match queue.device_default() {
             Ok(value) => println!("queue.device_default(): {:X}", value as intptr_t),
             Err(e) => println!("OpenCL error, queue.device_default(): {}", e),
         }
 
-        // CL_VERSION_3_0 value
+        #[cfg(feature = "CL_VERSION_3_0")]
         match queue.properties_array() {
             Ok(value) => println!("queue.properties_array(): {:?}", value),
             Err(e) => println!("OpenCL error, queue.properties_array(): {}", e),

--- a/src/context.rs
+++ b/src/context.rs
@@ -271,7 +271,8 @@ impl Context {
         pfn_notify: extern "C" fn(cl_context, *const c_void),
         user_data: *mut c_void,
     ) -> Result<()> {
-        set_context_destructor_callback(self.context, pfn_notify, user_data)
+        context::set_context_destructor_callback(self.context, pfn_notify, user_data)
+            .map_err(Into::into)
     }
 
     pub fn reference_count(&self) -> Result<cl_uint> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -200,7 +200,6 @@ impl Context {
 
     /// Get the common Shared Virtual Memory (SVM) capabilities of the
     /// devices in the Context.
-    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn get_svm_mem_capability(&self) -> cl_device_svm_capabilities {
         let device = Device::new(self.devices[0]);
         let mut svm_capability = device.svm_mem_capability();
@@ -272,11 +271,7 @@ impl Context {
         pfn_notify: extern "C" fn(cl_context, *const c_void),
         user_data: *mut c_void,
     ) -> Result<()> {
-        Ok(context::set_context_destructor_callback(
-            self.context,
-            pfn_notify,
-            user_data,
-        )?)
+        set_context_destructor_callback(self.context, pfn_notify, user_data)
     }
 
     pub fn reference_count(&self) -> Result<cl_uint> {
@@ -356,7 +351,6 @@ mod tests {
         let device = Device::new(devices[0]);
         let context = Context::from_device(&device).unwrap();
 
-        #[cfg(feature = "CL_VERSION_2_0")]
         println!(
             "CL_DEVICE_SVM_CAPABILITIES: {:X}",
             context.get_svm_mem_capability()

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::device::{Device, SubDevice};
+use super::device::Device;
+#[cfg(feature = "CL_VERSION_1_2")]
+use super::device::SubDevice;
 use super::Result;
 
 use cl3::context;
@@ -149,6 +151,7 @@ impl Context {
     ///
     /// returns a Result containing the new OpenCL context
     /// or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn from_sub_devices(
         sub_devices: &[SubDevice],
         properties: &[cl_context_properties],
@@ -197,6 +200,7 @@ impl Context {
 
     /// Get the common Shared Virtual Memory (SVM) capabilities of the
     /// devices in the Context.
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn get_svm_mem_capability(&self) -> cl_device_svm_capabilities {
         let device = Device::new(self.devices[0]);
         let mut svm_capability = device.svm_mem_capability();
@@ -268,7 +272,11 @@ impl Context {
         pfn_notify: extern "C" fn(cl_context, *const c_void),
         user_data: *mut c_void,
     ) -> Result<()> {
-        set_context_destructor_callback(self.context, pfn_notify, user_data)
+        Ok(context::set_context_destructor_callback(
+            self.context,
+            pfn_notify,
+            user_data,
+        )?)
     }
 
     pub fn reference_count(&self) -> Result<cl_uint> {
@@ -348,6 +356,7 @@ mod tests {
         let device = Device::new(devices[0]);
         let context = Context::from_device(&device).unwrap();
 
+        #[cfg(feature = "CL_VERSION_2_0")]
         println!(
             "CL_DEVICE_SVM_CAPABILITIES: {:X}",
             context.get_svm_mem_capability()

--- a/src/device.rs
+++ b/src/device.rs
@@ -16,9 +16,14 @@ pub use cl3::device::*;
 pub use cl3::ffi::cl_ext::{cl_amd_device_topology, CL_LUID_SIZE_KHR, CL_UUID_SIZE_KHR};
 
 use super::Result;
+#[cfg(feature = "CL_VERSION_1_2")]
+use cl3::types::cl_device_partition_property;
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl3::types::cl_device_svm_capabilities;
+#[cfg(feature = "CL_VERSION_3_0")]
+use cl3::types::cl_name_version;
 use cl3::types::{
-    cl_device_fp_config, cl_device_id, cl_device_partition_property, cl_device_svm_capabilities,
-    cl_device_type, cl_name_version, cl_platform_id, cl_uint, cl_ulong, CL_FALSE,
+    cl_device_fp_config, cl_device_id, cl_device_type, cl_platform_id, cl_uint, cl_ulong, CL_FALSE,
 };
 use libc::{intptr_t, size_t};
 
@@ -37,19 +42,23 @@ pub fn device_type_text(dev_type: cl_device_type) -> &'static str {
     }
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 #[derive(Debug)]
 pub struct SubDevice {
     id: cl_device_id,
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 impl Drop for SubDevice {
     fn drop(&mut self) {
         release_device(self.id()).expect("Error: clReleaseDevice");
     }
 }
 
+#[cfg(feature = "CL_VERSION_1_2")]
 unsafe impl Send for SubDevice {}
 
+#[cfg(feature = "CL_VERSION_1_2")]
 impl SubDevice {
     pub fn new(id: cl_device_id) -> SubDevice {
         SubDevice { id }
@@ -89,6 +98,7 @@ impl Device {
     ///
     /// returns a Result containing a vector of available SubDevices
     /// or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn create_sub_devices(
         &self,
         properties: &[cl_device_partition_property],
@@ -345,6 +355,7 @@ impl Device {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PLATFORM)?.to_ptr() as cl_platform_id)
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn double_fp_config(&self) -> Result<cl_ulong> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_DOUBLE_FP_CONFIG)?.to_ulong())
     }
@@ -400,6 +411,7 @@ impl Device {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_OPENCL_C_VERSION)?.to_string())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn linker_available(&self) -> Result<bool> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_LINKER_AVAILABLE)?.to_uint()
@@ -407,18 +419,22 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn built_in_kernels(&self) -> Result<String> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_BUILT_IN_KERNELS)?.to_string())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn image_max_buffer_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IMAGE_MAX_BUFFER_SIZE)?.to_size())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn image_max_array_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IMAGE_MAX_ARRAY_SIZE)?.to_size())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn parent_device(&self) -> Result<cl_device_id> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARENT_DEVICE)?.to_ptr()
@@ -426,13 +442,17 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn partition_max_sub_devices(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_MAX_SUB_DEVICES)?.to_uint())
     }
+
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn partition_properties(&self) -> Result<Vec<intptr_t>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_PROPERTIES)?.to_vec_intptr())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn partition_affinity_domain(&self) -> Result<Vec<cl_ulong>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_AFFINITY_DOMAIN)?
@@ -440,14 +460,17 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn partition_type(&self) -> Result<Vec<intptr_t>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_TYPE)?.to_vec_intptr())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn reference_count(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_REFERENCE_COUNT)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn preferred_interop_user_sync(&self) -> Result<bool> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_PREFERRED_INTEROP_USER_SYNC)?
@@ -456,15 +479,17 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn printf_buffer_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PRINTF_BUFFER_SIZE)?.to_size())
     }
 
-    // CL_VERSION_2_0
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn image_pitch_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IMAGE_PITCH_ALIGNMENT)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn image_base_address_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -473,14 +498,17 @@ impl Device {
         .to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn max_read_write_image_args(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn max_global_variable_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE)?.to_size())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn queue_on_device_properties(&self) -> Result<Vec<intptr_t>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES)?
@@ -488,6 +516,7 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn queue_on_device_preferred_size(&self) -> Result<size_t> {
         Ok(get_device_info(
             self.id(),
@@ -496,22 +525,27 @@ impl Device {
         .to_size())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn queue_on_device_max_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE)?.to_size())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn max_on_device_queues(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_ON_DEVICE_QUEUES)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn max_on_device_events(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_ON_DEVICE_EVENTS)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn svm_capabilities(&self) -> Result<cl_device_svm_capabilities> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_SVM_CAPABILITIES)?.to_ulong())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn global_variable_preferred_total_size(&self) -> Result<size_t> {
         Ok(get_device_info(
             self.id(),
@@ -520,10 +554,12 @@ impl Device {
         .to_size())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn max_pipe_args(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_PIPE_ARGS)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn pipe_max_active_reservations(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -532,10 +568,12 @@ impl Device {
         .to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn pipe_max_packet_size(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PIPE_MAX_PACKET_SIZE)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn preferred_platform_atomic_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -544,6 +582,7 @@ impl Device {
         .to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn preferred_global_atomic_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -552,6 +591,7 @@ impl Device {
         .to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn preferred_local_atomic_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -560,15 +600,17 @@ impl Device {
         .to_uint())
     }
 
-    // CL_VERSION_2_1
+    #[cfg(feature = "CL_VERSION_2_1")]
     pub fn il_version(&self) -> Result<String> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IL_VERSION)?.to_string())
     }
 
+    #[cfg(feature = "CL_VERSION_2_1")]
     pub fn max_num_sub_groups(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_NUM_SUB_GROUPS)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_2_1")]
     pub fn sub_group_independent_forward_progress(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -578,11 +620,12 @@ impl Device {
             != CL_FALSE)
     }
 
-    // CL_VERSION_3_0
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn numeric_version(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_NUMERIC_VERSION)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn extensions_with_version(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_EXTENSIONS_WITH_VERSION)?
@@ -590,6 +633,7 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn ils_with_version(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_ILS_WITH_VERSION)?
@@ -597,6 +641,7 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn built_in_kernels_with_version(&self) -> Result<Vec<cl_name_version>> {
         Ok(get_device_info(
             self.id(),
@@ -604,6 +649,8 @@ impl Device {
         )?
         .to_vec_name_version())
     }
+
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn atomic_memory_capabilities(&self) -> Result<cl_ulong> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES)?
@@ -611,10 +658,12 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn atomic_fence_capabilities(&self) -> Result<cl_ulong> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_ATOMIC_FENCE_CAPABILITIES)?.to_ulong())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn non_uniform_work_group_support(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -624,6 +673,7 @@ impl Device {
             != CL_FALSE)
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn opencl_c_all_versions(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_OPENCL_C_ALL_VERSIONS)?
@@ -631,6 +681,7 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn preferred_work_group_size_multiple(&self) -> Result<size_t> {
         Ok(get_device_info(
             self.id(),
@@ -639,6 +690,7 @@ impl Device {
         .to_size())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn work_group_collective_functions_support(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -648,6 +700,7 @@ impl Device {
             != CL_FALSE)
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn generic_address_space_support(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -657,26 +710,32 @@ impl Device {
             != CL_FALSE)
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn uuid_khr(&self) -> Result<Vec<u8>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_UUID_KHR)?.to_vec_uchar())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn driver_uuid_khr(&self) -> Result<Vec<u8>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DRIVER_UUID_KHR)?.to_vec_uchar())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn luid_valid_khr(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_LUID_VALID_KHR)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn luid_khr(&self) -> Result<Vec<u8>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_LUID_KHR)?.to_vec_uchar())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn node_mask_khr(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_NODE_MASK_KHR)?.to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn opencl_c_features(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_OPENCL_C_FEATURES)?
@@ -684,6 +743,7 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn device_enqueue_capabilities(&self) -> Result<cl_ulong> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES)?
@@ -691,10 +751,12 @@ impl Device {
         )
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn pipe_support(&self) -> Result<bool> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PIPE_SUPPORT)?.to_uint() != CL_FALSE)
     }
 
+    #[cfg(feature = "CL_VERSION_3_0")]
     pub fn latest_conformance_version_passed(&self) -> Result<String> {
         Ok(get_device_info(
             self.id(),
@@ -874,6 +936,7 @@ impl Device {
     }
     /// Determine if the device supports the given double floating point capability.  
     /// Returns true if the device supports it, false otherwise.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn supports_double(&self, min_fp_capability: cl_device_fp_config) -> bool {
         if let Ok(fp) = self.double_fp_config() {
             0 < fp & min_fp_capability
@@ -884,6 +947,7 @@ impl Device {
 
     /// Determine if the device supports SVM and, if so, what kind of SVM.  
     /// Returns zero if the device does not support SVM.
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn svm_mem_capability(&self) -> cl_device_svm_capabilities {
         if let Ok(svm) = self.svm_capabilities() {
             svm
@@ -897,6 +961,7 @@ impl Device {
 mod tests {
     use super::*;
     use crate::platform::get_platforms;
+    #[cfg(feature = "CL_VERSION_1_2")]
     use std::ptr;
 
     #[test]
@@ -926,6 +991,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     #[test]
     fn test_get_sub_devices() {
         let platforms = get_platforms().unwrap();
@@ -1192,6 +1258,7 @@ mod tests {
         assert_eq!(platform.id(), value);
 
         // Device may not support double fp precision
+        #[cfg(feature = "CL_VERSION_1_2")]
         match device.double_fp_config() {
             Ok(value) => {
                 println!("CL_DEVICE_DOUBLE_FP_CONFIG: {:X}", value)
@@ -1243,422 +1310,432 @@ mod tests {
         println!("CL_DEVICE_OPENCL_C_VERSION: {}", value);
         assert!(!value.is_empty());
 
-        let value = device.linker_available().unwrap();
-        println!("CL_DEVICE_LINKER_AVAILABLE: {}", value);
+        #[cfg(feature = "CL_VERSION_1_2")]
+        {
+            let value = device.linker_available().unwrap();
+            println!("CL_DEVICE_LINKER_AVAILABLE: {}", value);
 
-        let value = device.built_in_kernels().unwrap();
-        println!("CL_DEVICE_BUILT_IN_KERNELS: {:?}", value);
+            let value = device.built_in_kernels().unwrap();
+            println!("CL_DEVICE_BUILT_IN_KERNELS: {:?}", value);
 
-        let value = device.image_max_buffer_size().unwrap();
-        println!("CL_DEVICE_IMAGE_MAX_BUFFER_SIZE: {}", value);
-        assert!(0 < value);
+            let value = device.image_max_buffer_size().unwrap();
+            println!("CL_DEVICE_IMAGE_MAX_BUFFER_SIZE: {}", value);
+            assert!(0 < value);
 
-        let value = device.image_max_array_size().unwrap();
-        println!("CL_DEVICE_IMAGE_MAX_ARRAY_SIZE: {}", value);
-        assert!(0 < value);
+            let value = device.image_max_array_size().unwrap();
+            println!("CL_DEVICE_IMAGE_MAX_ARRAY_SIZE: {}", value);
+            assert!(0 < value);
 
-        let value = device.parent_device().unwrap();
-        println!("CL_DEVICE_PARENT_DEVICE: {:X}", value as intptr_t);
-        let value = device.partition_max_sub_devices().unwrap();
-        println!("CL_DEVICE_PARTITION_MAX_SUB_DEVICES: {}", value);
+            let value = device.parent_device().unwrap();
+            println!("CL_DEVICE_PARENT_DEVICE: {:X}", value as intptr_t);
+            let value = device.partition_max_sub_devices().unwrap();
+            println!("CL_DEVICE_PARTITION_MAX_SUB_DEVICES: {}", value);
 
-        let value = device.partition_properties().unwrap();
-        println!("CL_DEVICE_PARTITION_PROPERTIES: {:?}", value);
-        assert!(0 < value.len());
+            let value = device.partition_properties().unwrap();
+            println!("CL_DEVICE_PARTITION_PROPERTIES: {:?}", value);
+            assert!(0 < value.len());
 
-        let value = device.partition_affinity_domain().unwrap();
-        println!("CL_DEVICE_PARTITION_AFFINITY_DOMAIN: {:?}", value);
-        assert!(0 < value.len());
+            let value = device.partition_affinity_domain().unwrap();
+            println!("CL_DEVICE_PARTITION_AFFINITY_DOMAIN: {:?}", value);
+            assert!(0 < value.len());
 
-        let value = device.partition_type().unwrap();
-        println!("CL_DEVICE_PARTITION_TYPE: {:?}", value);
-        // assert!(0 < value.len());
+            let value = device.partition_type().unwrap();
+            println!("CL_DEVICE_PARTITION_TYPE: {:?}", value);
+            // assert!(0 < value.len());
 
-        let value = device.reference_count().unwrap();
-        println!("CL_DEVICE_REFERENCE_COUNT: {}", value);
-        assert!(0 < value);
+            let value = device.reference_count().unwrap();
+            println!("CL_DEVICE_REFERENCE_COUNT: {}", value);
+            assert!(0 < value);
 
-        let value = device.preferred_interop_user_sync().unwrap();
-        println!("CL_DEVICE_PREFERRED_INTEROP_USER_SYNC: {}", value);
+            let value = device.preferred_interop_user_sync().unwrap();
+            println!("CL_DEVICE_PREFERRED_INTEROP_USER_SYNC: {}", value);
 
-        let value = device.printf_buffer_size().unwrap();
-        println!("CL_DEVICE_PRINTF_BUFFER_SIZE: {}", value);
-        assert!(0 < value);
+            let value = device.printf_buffer_size().unwrap();
+            println!("CL_DEVICE_PRINTF_BUFFER_SIZE: {}", value);
+            assert!(0 < value);
+        }
 
         //////////////////////////////////////////////////////////////////////
         // CL_VERSION_2_0 parameters
-        match device.image_pitch_alignment() {
-            Ok(value) => {
-                println!("CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {:?}, {}",
-                e, e
-            ),
-        };
+        #[cfg(feature = "CL_VERSION_2_0")]
+        {
+            match device.image_pitch_alignment() {
+                Ok(value) => {
+                    println!("CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.image_base_address_alignment() {
-            Ok(value) => {
-                println!("CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.image_base_address_alignment() {
+                Ok(value) => {
+                    println!("CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.max_read_write_image_args() {
-            Ok(value) => {
-                println!("CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.max_read_write_image_args() {
+                Ok(value) => {
+                    println!("CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.max_global_variable_size() {
-            Ok(value) => {
-                println!("CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.max_global_variable_size() {
+                Ok(value) => {
+                    println!("CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.queue_on_device_properties() {
-            Ok(value) => {
-                println!("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.queue_on_device_properties() {
+                Ok(value) => {
+                    println!("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.queue_on_device_preferred_size() {
-            Ok(value) => {
-                println!("CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.queue_on_device_preferred_size() {
+                Ok(value) => {
+                    println!("CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.queue_on_device_max_size() {
-            Ok(value) => {
-                println!("CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.queue_on_device_max_size() {
+                Ok(value) => {
+                    println!("CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.max_on_device_queues() {
-            Ok(value) => {
-                println!("CL_DEVICE_MAX_ON_DEVICE_QUEUES: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_QUEUES: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.max_on_device_queues() {
+                Ok(value) => {
+                    println!("CL_DEVICE_MAX_ON_DEVICE_QUEUES: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_QUEUES: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.max_on_device_events() {
-            Ok(value) => {
-                println!("CL_DEVICE_MAX_ON_DEVICE_EVENTS: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_EVENTS: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.max_on_device_events() {
+                Ok(value) => {
+                    println!("CL_DEVICE_MAX_ON_DEVICE_EVENTS: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_EVENTS: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.svm_capabilities() {
-            Ok(value) => {
-                println!("CL_DEVICE_SVM_CAPABILITIES: {}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_SVM_CAPABILITIES: {:?}, {}", e, e),
-        };
+            match device.svm_capabilities() {
+                Ok(value) => {
+                    println!("CL_DEVICE_SVM_CAPABILITIES: {}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_SVM_CAPABILITIES: {:?}, {}", e, e),
+            };
 
-        match device.global_variable_preferred_total_size() {
-            Ok(value) => {
-                println!("CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.global_variable_preferred_total_size() {
+                Ok(value) => {
+                    println!("CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.max_pipe_args() {
-            Ok(value) => {
-                println!("CL_DEVICE_MAX_PIPE_ARGS: {}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_MAX_PIPE_ARGS: {:?}, {}", e, e),
-        };
+            match device.max_pipe_args() {
+                Ok(value) => {
+                    println!("CL_DEVICE_MAX_PIPE_ARGS: {}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_MAX_PIPE_ARGS: {:?}, {}", e, e),
+            };
 
-        match device.pipe_max_active_reservations() {
-            Ok(value) => {
-                println!("CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.pipe_max_active_reservations() {
+                Ok(value) => {
+                    println!("CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.pipe_max_packet_size() {
-            Ok(value) => {
-                println!("CL_DEVICE_PIPE_MAX_PACKET_SIZE: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_PIPE_MAX_PACKET_SIZE: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.pipe_max_packet_size() {
+                Ok(value) => {
+                    println!("CL_DEVICE_PIPE_MAX_PACKET_SIZE: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_PIPE_MAX_PACKET_SIZE: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.preferred_platform_atomic_alignment() {
-            Ok(value) => {
-                println!("CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.preferred_platform_atomic_alignment() {
+                Ok(value) => {
+                    println!("CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.preferred_global_atomic_alignment() {
-            Ok(value) => {
-                println!("CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.preferred_global_atomic_alignment() {
+                Ok(value) => {
+                    println!("CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.preferred_local_atomic_alignment() {
-            Ok(value) => {
-                println!("CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.preferred_local_atomic_alignment() {
+                Ok(value) => {
+                    println!("CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {:?}, {}",
+                    e, e
+                ),
+            };
+        }
 
-        // //////////////////////////////////////////////////////////////////////
-        // // CL_VERSION_2_1 parameters
+        //////////////////////////////////////////////////////////////////////
+        // CL_VERSION_2_1 parameters
+        #[cfg(feature = "CL_VERSION_2_1")]
+        {
+            match device.il_version() {
+                Ok(value) => {
+                    println!("CL_DEVICE_IL_VERSION: {:?}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_IL_VERSION: {:?}, {}", e, e),
+            };
 
-        match device.il_version() {
-            Ok(value) => {
-                println!("CL_DEVICE_IL_VERSION: {:?}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_IL_VERSION: {:?}, {}", e, e),
-        };
+            match device.max_num_sub_groups() {
+                Ok(value) => {
+                    println!("CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}, {}", e, e),
+            };
 
-        match device.max_num_sub_groups() {
-            Ok(value) => {
-                println!("CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}, {}", e, e),
-        };
-
-        match device.sub_group_independent_forward_progress() {
-            Ok(value) => {
-                println!(
-                    "CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {:?}",
-                    value
-                )
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS:{:?}, {}",
-                e, e
-            ),
-        };
+            match device.sub_group_independent_forward_progress() {
+                Ok(value) => {
+                    println!(
+                        "CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {:?}",
+                        value
+                    )
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS:{:?}, {}",
+                    e, e
+                ),
+            };
+        }
 
         //////////////////////////////////////////////////////////////////////
         // CL_VERSION_3_0 parameters
+        #[cfg(feature = "CL_VERSION_3_0")]
+        {
+            match device.numeric_version() {
+                Ok(value) => {
+                    println!("CL_DEVICE_NUMERIC_VERSION: {:X}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_NUMERIC_VERSION: {:?}, {}", e, e),
+            };
 
-        match device.numeric_version() {
-            Ok(value) => {
-                println!("CL_DEVICE_NUMERIC_VERSION: {:X}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_NUMERIC_VERSION: {:?}, {}", e, e),
-        };
+            match device.extensions_with_version() {
+                Ok(value) => {
+                    println!("CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.extensions_with_version() {
-            Ok(value) => {
-                println!("CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.ils_with_version() {
+                Ok(value) => {
+                    println!("CL_DEVICE_ILS_WITH_VERSION: {:?}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_ILS_WITH_VERSION: {:?}, {}", e, e),
+            };
 
-        match device.ils_with_version() {
-            Ok(value) => {
-                println!("CL_DEVICE_ILS_WITH_VERSION: {:?}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_ILS_WITH_VERSION: {:?}, {}", e, e),
-        };
+            match device.built_in_kernels_with_version() {
+                Ok(value) => {
+                    println!("CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.built_in_kernels_with_version() {
-            Ok(value) => {
-                println!("CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.atomic_memory_capabilities() {
+                Ok(value) => {
+                    println!("CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:X}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.atomic_memory_capabilities() {
-            Ok(value) => {
-                println!("CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:X}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.atomic_fence_capabilities() {
+                Ok(value) => {
+                    println!("CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:X}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.atomic_fence_capabilities() {
-            Ok(value) => {
-                println!("CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:X}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.non_uniform_work_group_support() {
+                Ok(value) => {
+                    println!("CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.non_uniform_work_group_support() {
-            Ok(value) => {
-                println!("CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.opencl_c_all_versions() {
+                Ok(value) => {
+                    println!("CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.opencl_c_all_versions() {
-            Ok(value) => {
-                println!("CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.preferred_work_group_size_multiple() {
+                Ok(value) => {
+                    println!("CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.preferred_work_group_size_multiple() {
-            Ok(value) => {
-                println!("CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.work_group_collective_functions_support() {
+                Ok(value) => {
+                    println!(
+                        "CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {}",
+                        value
+                    )
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.work_group_collective_functions_support() {
-            Ok(value) => {
-                println!(
-                    "CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {}",
-                    value
-                )
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.generic_address_space_support() {
+                Ok(value) => {
+                    println!("CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.generic_address_space_support() {
-            Ok(value) => {
-                println!("CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.uuid_khr() {
+                Ok(value) => {
+                    println!("CL_DEVICE_UUID_KHR: {:?}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_UUID_KHR: {:?}, {}", e, e),
+            };
 
-        match device.uuid_khr() {
-            Ok(value) => {
-                println!("CL_DEVICE_UUID_KHR: {:?}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_UUID_KHR: {:?}, {}", e, e),
-        };
+            match device.driver_uuid_khr() {
+                Ok(value) => {
+                    println!("CL_DRIVER_UUID_KHR: {:?}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DRIVER_UUID_KHR: {:?}, {}", e, e),
+            };
 
-        match device.driver_uuid_khr() {
-            Ok(value) => {
-                println!("CL_DRIVER_UUID_KHR: {:?}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DRIVER_UUID_KHR: {:?}, {}", e, e),
-        };
+            match device.luid_valid_khr() {
+                Ok(value) => {
+                    println!("CL_DEVICE_LUID_VALID_KHR: {}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_LUID_VALID_KHR: {:?}, {}", e, e),
+            };
 
-        match device.luid_valid_khr() {
-            Ok(value) => {
-                println!("CL_DEVICE_LUID_VALID_KHR: {}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_LUID_VALID_KHR: {:?}, {}", e, e),
-        };
+            match device.luid_khr() {
+                Ok(value) => {
+                    println!("CL_DEVICE_LUID_KHR: {:?}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_LUID_KHR: {:?}, {}", e, e),
+            };
 
-        match device.luid_khr() {
-            Ok(value) => {
-                println!("CL_DEVICE_LUID_KHR: {:?}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_LUID_KHR: {:?}, {}", e, e),
-        };
+            match device.node_mask_khr() {
+                Ok(value) => {
+                    println!("CL_DEVICE_NODE_MASK_KHR: {}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_NODE_MASK_KHR: {:?}, {}", e, e),
+            };
 
-        match device.node_mask_khr() {
-            Ok(value) => {
-                println!("CL_DEVICE_NODE_MASK_KHR: {}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_NODE_MASK_KHR: {:?}, {}", e, e),
-        };
+            match device.opencl_c_features() {
+                Ok(value) => {
+                    println!("CL_DEVICE_OPENCL_C_FEATURES: {:?}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_OPENCL_C_FEATURES: {:?}, {}", e, e),
+            };
 
-        match device.opencl_c_features() {
-            Ok(value) => {
-                println!("CL_DEVICE_OPENCL_C_FEATURES: {:?}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_OPENCL_C_FEATURES: {:?}, {}", e, e),
-        };
+            match device.device_enqueue_capabilities() {
+                Ok(value) => {
+                    println!("CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:X}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:?}, {}",
+                    e, e
+                ),
+            };
 
-        match device.device_enqueue_capabilities() {
-            Ok(value) => {
-                println!("CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:X}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.pipe_support() {
+                Ok(value) => {
+                    println!("CL_DEVICE_PIPE_SUPPORT: {}", value)
+                }
+                Err(e) => println!("OpenCL error, CL_DEVICE_PIPE_SUPPORT: {:?}, {}", e, e),
+            };
 
-        match device.pipe_support() {
-            Ok(value) => {
-                println!("CL_DEVICE_PIPE_SUPPORT: {}", value)
-            }
-            Err(e) => println!("OpenCL error, CL_DEVICE_PIPE_SUPPORT: {:?}, {}", e, e),
-        };
-
-        match device.latest_conformance_version_passed() {
-            Ok(value) => {
-                println!("CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}", value)
-            }
-            Err(e) => println!(
-                "OpenCL error, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}, {}",
-                e, e
-            ),
-        };
+            match device.latest_conformance_version_passed() {
+                Ok(value) => {
+                    println!("CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}", value)
+                }
+                Err(e) => println!(
+                    "OpenCL error, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}, {}",
+                    e, e
+                ),
+            };
+        }
 
         match device.integer_dot_product_capabilities_khr() {
             Ok(value) => {

--- a/src/device.rs
+++ b/src/device.rs
@@ -16,14 +16,10 @@ pub use cl3::device::*;
 pub use cl3::ffi::cl_ext::{cl_amd_device_topology, CL_LUID_SIZE_KHR, CL_UUID_SIZE_KHR};
 
 use super::Result;
-#[cfg(feature = "CL_VERSION_1_2")]
-use cl3::types::cl_device_partition_property;
-#[cfg(feature = "CL_VERSION_2_0")]
-use cl3::types::cl_device_svm_capabilities;
-#[cfg(feature = "CL_VERSION_3_0")]
-use cl3::types::cl_name_version;
+#[allow(unused_imports)]
 use cl3::types::{
-    cl_device_fp_config, cl_device_id, cl_device_type, cl_platform_id, cl_uint, cl_ulong, CL_FALSE,
+    cl_device_fp_config, cl_device_id, cl_device_partition_property, cl_device_svm_capabilities,
+    cl_device_type, cl_name_version, cl_platform_id, cl_uint, cl_ulong, CL_FALSE,
 };
 use libc::{intptr_t, size_t};
 
@@ -355,7 +351,7 @@ impl Device {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PLATFORM)?.to_ptr() as cl_platform_id)
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn double_fp_config(&self) -> Result<cl_ulong> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_DOUBLE_FP_CONFIG)?.to_ulong())
     }
@@ -411,7 +407,7 @@ impl Device {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_OPENCL_C_VERSION)?.to_string())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn linker_available(&self) -> Result<bool> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_LINKER_AVAILABLE)?.to_uint()
@@ -419,22 +415,22 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn built_in_kernels(&self) -> Result<String> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_BUILT_IN_KERNELS)?.to_string())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn image_max_buffer_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IMAGE_MAX_BUFFER_SIZE)?.to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn image_max_array_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IMAGE_MAX_ARRAY_SIZE)?.to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn parent_device(&self) -> Result<cl_device_id> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARENT_DEVICE)?.to_ptr()
@@ -442,17 +438,17 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn partition_max_sub_devices(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_MAX_SUB_DEVICES)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn partition_properties(&self) -> Result<Vec<intptr_t>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_PROPERTIES)?.to_vec_intptr())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn partition_affinity_domain(&self) -> Result<Vec<cl_ulong>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_AFFINITY_DOMAIN)?
@@ -460,17 +456,17 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn partition_type(&self) -> Result<Vec<intptr_t>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PARTITION_TYPE)?.to_vec_intptr())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn reference_count(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_REFERENCE_COUNT)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn preferred_interop_user_sync(&self) -> Result<bool> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_PREFERRED_INTEROP_USER_SYNC)?
@@ -479,17 +475,17 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_1_2")]
+    /// CL_VERSION_1_2
     pub fn printf_buffer_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PRINTF_BUFFER_SIZE)?.to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn image_pitch_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IMAGE_PITCH_ALIGNMENT)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn image_base_address_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -498,17 +494,17 @@ impl Device {
         .to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn max_read_write_image_args(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn max_global_variable_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE)?.to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn queue_on_device_properties(&self) -> Result<Vec<intptr_t>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES)?
@@ -516,7 +512,7 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn queue_on_device_preferred_size(&self) -> Result<size_t> {
         Ok(get_device_info(
             self.id(),
@@ -525,27 +521,27 @@ impl Device {
         .to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn queue_on_device_max_size(&self) -> Result<size_t> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE)?.to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn max_on_device_queues(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_ON_DEVICE_QUEUES)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn max_on_device_events(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_ON_DEVICE_EVENTS)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn svm_capabilities(&self) -> Result<cl_device_svm_capabilities> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_SVM_CAPABILITIES)?.to_ulong())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn global_variable_preferred_total_size(&self) -> Result<size_t> {
         Ok(get_device_info(
             self.id(),
@@ -554,12 +550,12 @@ impl Device {
         .to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn max_pipe_args(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_PIPE_ARGS)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn pipe_max_active_reservations(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -568,12 +564,12 @@ impl Device {
         .to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn pipe_max_packet_size(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PIPE_MAX_PACKET_SIZE)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn preferred_platform_atomic_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -582,7 +578,7 @@ impl Device {
         .to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn preferred_global_atomic_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -591,7 +587,7 @@ impl Device {
         .to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn preferred_local_atomic_alignment(&self) -> Result<cl_uint> {
         Ok(get_device_info(
             self.id(),
@@ -600,17 +596,17 @@ impl Device {
         .to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_1")]
+    /// CL_VERSION_2_1
     pub fn il_version(&self) -> Result<String> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_IL_VERSION)?.to_string())
     }
 
-    #[cfg(feature = "CL_VERSION_2_1")]
+    /// CL_VERSION_2_1
     pub fn max_num_sub_groups(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_MAX_NUM_SUB_GROUPS)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_1")]
+    /// CL_VERSION_2_1
     pub fn sub_group_independent_forward_progress(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -620,12 +616,12 @@ impl Device {
             != CL_FALSE)
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn numeric_version(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_NUMERIC_VERSION)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn extensions_with_version(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_EXTENSIONS_WITH_VERSION)?
@@ -633,7 +629,7 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn ils_with_version(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_ILS_WITH_VERSION)?
@@ -641,7 +637,7 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn built_in_kernels_with_version(&self) -> Result<Vec<cl_name_version>> {
         Ok(get_device_info(
             self.id(),
@@ -650,7 +646,7 @@ impl Device {
         .to_vec_name_version())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn atomic_memory_capabilities(&self) -> Result<cl_ulong> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES)?
@@ -658,12 +654,12 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn atomic_fence_capabilities(&self) -> Result<cl_ulong> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_ATOMIC_FENCE_CAPABILITIES)?.to_ulong())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn non_uniform_work_group_support(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -673,7 +669,7 @@ impl Device {
             != CL_FALSE)
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn opencl_c_all_versions(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_OPENCL_C_ALL_VERSIONS)?
@@ -681,7 +677,7 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn preferred_work_group_size_multiple(&self) -> Result<size_t> {
         Ok(get_device_info(
             self.id(),
@@ -690,7 +686,7 @@ impl Device {
         .to_size())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn work_group_collective_functions_support(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -700,7 +696,7 @@ impl Device {
             != CL_FALSE)
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn generic_address_space_support(&self) -> Result<bool> {
         Ok(get_device_info(
             self.id(),
@@ -710,32 +706,32 @@ impl Device {
             != CL_FALSE)
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn uuid_khr(&self) -> Result<Vec<u8>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_UUID_KHR)?.to_vec_uchar())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn driver_uuid_khr(&self) -> Result<Vec<u8>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DRIVER_UUID_KHR)?.to_vec_uchar())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn luid_valid_khr(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_LUID_VALID_KHR)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn luid_khr(&self) -> Result<Vec<u8>> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_LUID_KHR)?.to_vec_uchar())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn node_mask_khr(&self) -> Result<cl_uint> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_NODE_MASK_KHR)?.to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn opencl_c_features(&self) -> Result<Vec<cl_name_version>> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_OPENCL_C_FEATURES)?
@@ -743,7 +739,7 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn device_enqueue_capabilities(&self) -> Result<cl_ulong> {
         Ok(
             get_device_info(self.id(), DeviceInfo::CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES)?
@@ -751,12 +747,12 @@ impl Device {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn pipe_support(&self) -> Result<bool> {
         Ok(get_device_info(self.id(), DeviceInfo::CL_DEVICE_PIPE_SUPPORT)?.to_uint() != CL_FALSE)
     }
 
-    #[cfg(feature = "CL_VERSION_3_0")]
+    /// CL_VERSION_3_0
     pub fn latest_conformance_version_passed(&self) -> Result<String> {
         Ok(get_device_info(
             self.id(),
@@ -936,7 +932,8 @@ impl Device {
     }
     /// Determine if the device supports the given double floating point capability.  
     /// Returns true if the device supports it, false otherwise.
-    #[cfg(feature = "CL_VERSION_1_2")]
+    ///
+    /// CL_VERSION_1_2
     pub fn supports_double(&self, min_fp_capability: cl_device_fp_config) -> bool {
         if let Ok(fp) = self.double_fp_config() {
             0 < fp & min_fp_capability
@@ -947,7 +944,8 @@ impl Device {
 
     /// Determine if the device supports SVM and, if so, what kind of SVM.  
     /// Returns zero if the device does not support SVM.
-    #[cfg(feature = "CL_VERSION_2_0")]
+    ///
+    /// CL_VERSION_2_0
     pub fn svm_mem_capability(&self) -> cl_device_svm_capabilities {
         if let Ok(svm) = self.svm_capabilities() {
             svm
@@ -1258,7 +1256,6 @@ mod tests {
         assert_eq!(platform.id(), value);
 
         // Device may not support double fp precision
-        #[cfg(feature = "CL_VERSION_1_2")]
         match device.double_fp_config() {
             Ok(value) => {
                 println!("CL_DEVICE_DOUBLE_FP_CONFIG: {:X}", value)
@@ -1310,432 +1307,422 @@ mod tests {
         println!("CL_DEVICE_OPENCL_C_VERSION: {}", value);
         assert!(!value.is_empty());
 
-        #[cfg(feature = "CL_VERSION_1_2")]
-        {
-            let value = device.linker_available().unwrap();
-            println!("CL_DEVICE_LINKER_AVAILABLE: {}", value);
+        let value = device.linker_available().unwrap();
+        println!("CL_DEVICE_LINKER_AVAILABLE: {}", value);
 
-            let value = device.built_in_kernels().unwrap();
-            println!("CL_DEVICE_BUILT_IN_KERNELS: {:?}", value);
+        let value = device.built_in_kernels().unwrap();
+        println!("CL_DEVICE_BUILT_IN_KERNELS: {:?}", value);
 
-            let value = device.image_max_buffer_size().unwrap();
-            println!("CL_DEVICE_IMAGE_MAX_BUFFER_SIZE: {}", value);
-            assert!(0 < value);
+        let value = device.image_max_buffer_size().unwrap();
+        println!("CL_DEVICE_IMAGE_MAX_BUFFER_SIZE: {}", value);
+        assert!(0 < value);
 
-            let value = device.image_max_array_size().unwrap();
-            println!("CL_DEVICE_IMAGE_MAX_ARRAY_SIZE: {}", value);
-            assert!(0 < value);
+        let value = device.image_max_array_size().unwrap();
+        println!("CL_DEVICE_IMAGE_MAX_ARRAY_SIZE: {}", value);
+        assert!(0 < value);
 
-            let value = device.parent_device().unwrap();
-            println!("CL_DEVICE_PARENT_DEVICE: {:X}", value as intptr_t);
-            let value = device.partition_max_sub_devices().unwrap();
-            println!("CL_DEVICE_PARTITION_MAX_SUB_DEVICES: {}", value);
+        let value = device.parent_device().unwrap();
+        println!("CL_DEVICE_PARENT_DEVICE: {:X}", value as intptr_t);
+        let value = device.partition_max_sub_devices().unwrap();
+        println!("CL_DEVICE_PARTITION_MAX_SUB_DEVICES: {}", value);
 
-            let value = device.partition_properties().unwrap();
-            println!("CL_DEVICE_PARTITION_PROPERTIES: {:?}", value);
-            assert!(0 < value.len());
+        let value = device.partition_properties().unwrap();
+        println!("CL_DEVICE_PARTITION_PROPERTIES: {:?}", value);
+        assert!(0 < value.len());
 
-            let value = device.partition_affinity_domain().unwrap();
-            println!("CL_DEVICE_PARTITION_AFFINITY_DOMAIN: {:?}", value);
-            assert!(0 < value.len());
+        let value = device.partition_affinity_domain().unwrap();
+        println!("CL_DEVICE_PARTITION_AFFINITY_DOMAIN: {:?}", value);
+        assert!(0 < value.len());
 
-            let value = device.partition_type().unwrap();
-            println!("CL_DEVICE_PARTITION_TYPE: {:?}", value);
-            // assert!(0 < value.len());
+        let value = device.partition_type().unwrap();
+        println!("CL_DEVICE_PARTITION_TYPE: {:?}", value);
+        // assert!(0 < value.len());
 
-            let value = device.reference_count().unwrap();
-            println!("CL_DEVICE_REFERENCE_COUNT: {}", value);
-            assert!(0 < value);
+        let value = device.reference_count().unwrap();
+        println!("CL_DEVICE_REFERENCE_COUNT: {}", value);
+        assert!(0 < value);
 
-            let value = device.preferred_interop_user_sync().unwrap();
-            println!("CL_DEVICE_PREFERRED_INTEROP_USER_SYNC: {}", value);
+        let value = device.preferred_interop_user_sync().unwrap();
+        println!("CL_DEVICE_PREFERRED_INTEROP_USER_SYNC: {}", value);
 
-            let value = device.printf_buffer_size().unwrap();
-            println!("CL_DEVICE_PRINTF_BUFFER_SIZE: {}", value);
-            assert!(0 < value);
-        }
+        let value = device.printf_buffer_size().unwrap();
+        println!("CL_DEVICE_PRINTF_BUFFER_SIZE: {}", value);
+        assert!(0 < value);
 
         //////////////////////////////////////////////////////////////////////
         // CL_VERSION_2_0 parameters
-        #[cfg(feature = "CL_VERSION_2_0")]
-        {
-            match device.image_pitch_alignment() {
-                Ok(value) => {
-                    println!("CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.image_pitch_alignment() {
+            Ok(value) => {
+                println!("CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_IMAGE_PITCH_ALIGNMENT: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.image_base_address_alignment() {
-                Ok(value) => {
-                    println!("CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.image_base_address_alignment() {
+            Ok(value) => {
+                println!("CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.max_read_write_image_args() {
-                Ok(value) => {
-                    println!("CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.max_read_write_image_args() {
+            Ok(value) => {
+                println!("CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.max_global_variable_size() {
-                Ok(value) => {
-                    println!("CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.max_global_variable_size() {
+            Ok(value) => {
+                println!("CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.queue_on_device_properties() {
-                Ok(value) => {
-                    println!("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.queue_on_device_properties() {
+            Ok(value) => {
+                println!("CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.queue_on_device_preferred_size() {
-                Ok(value) => {
-                    println!("CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.queue_on_device_preferred_size() {
+            Ok(value) => {
+                println!("CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.queue_on_device_max_size() {
-                Ok(value) => {
-                    println!("CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.queue_on_device_max_size() {
+            Ok(value) => {
+                println!("CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.max_on_device_queues() {
-                Ok(value) => {
-                    println!("CL_DEVICE_MAX_ON_DEVICE_QUEUES: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_QUEUES: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.max_on_device_queues() {
+            Ok(value) => {
+                println!("CL_DEVICE_MAX_ON_DEVICE_QUEUES: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_QUEUES: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.max_on_device_events() {
-                Ok(value) => {
-                    println!("CL_DEVICE_MAX_ON_DEVICE_EVENTS: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_EVENTS: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.max_on_device_events() {
+            Ok(value) => {
+                println!("CL_DEVICE_MAX_ON_DEVICE_EVENTS: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_MAX_ON_DEVICE_EVENTS: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.svm_capabilities() {
-                Ok(value) => {
-                    println!("CL_DEVICE_SVM_CAPABILITIES: {}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_SVM_CAPABILITIES: {:?}, {}", e, e),
-            };
+        match device.svm_capabilities() {
+            Ok(value) => {
+                println!("CL_DEVICE_SVM_CAPABILITIES: {}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_SVM_CAPABILITIES: {:?}, {}", e, e),
+        };
 
-            match device.global_variable_preferred_total_size() {
-                Ok(value) => {
-                    println!("CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.global_variable_preferred_total_size() {
+            Ok(value) => {
+                println!("CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.max_pipe_args() {
-                Ok(value) => {
-                    println!("CL_DEVICE_MAX_PIPE_ARGS: {}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_MAX_PIPE_ARGS: {:?}, {}", e, e),
-            };
+        match device.max_pipe_args() {
+            Ok(value) => {
+                println!("CL_DEVICE_MAX_PIPE_ARGS: {}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_MAX_PIPE_ARGS: {:?}, {}", e, e),
+        };
 
-            match device.pipe_max_active_reservations() {
-                Ok(value) => {
-                    println!("CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.pipe_max_active_reservations() {
+            Ok(value) => {
+                println!("CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.pipe_max_packet_size() {
-                Ok(value) => {
-                    println!("CL_DEVICE_PIPE_MAX_PACKET_SIZE: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_PIPE_MAX_PACKET_SIZE: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.pipe_max_packet_size() {
+            Ok(value) => {
+                println!("CL_DEVICE_PIPE_MAX_PACKET_SIZE: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_PIPE_MAX_PACKET_SIZE: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.preferred_platform_atomic_alignment() {
-                Ok(value) => {
-                    println!("CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.preferred_platform_atomic_alignment() {
+            Ok(value) => {
+                println!("CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.preferred_global_atomic_alignment() {
-                Ok(value) => {
-                    println!("CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.preferred_global_atomic_alignment() {
+            Ok(value) => {
+                println!("CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.preferred_local_atomic_alignment() {
-                Ok(value) => {
-                    println!("CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {:?}, {}",
-                    e, e
-                ),
-            };
-        }
+        match device.preferred_local_atomic_alignment() {
+            Ok(value) => {
+                println!("CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT: {:?}, {}",
+                e, e
+            ),
+        };
 
-        //////////////////////////////////////////////////////////////////////
-        // CL_VERSION_2_1 parameters
-        #[cfg(feature = "CL_VERSION_2_1")]
-        {
-            match device.il_version() {
-                Ok(value) => {
-                    println!("CL_DEVICE_IL_VERSION: {:?}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_IL_VERSION: {:?}, {}", e, e),
-            };
+        // //////////////////////////////////////////////////////////////////////
+        // // CL_VERSION_2_1 parameters
 
-            match device.max_num_sub_groups() {
-                Ok(value) => {
-                    println!("CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}, {}", e, e),
-            };
+        match device.il_version() {
+            Ok(value) => {
+                println!("CL_DEVICE_IL_VERSION: {:?}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_IL_VERSION: {:?}, {}", e, e),
+        };
 
-            match device.sub_group_independent_forward_progress() {
-                Ok(value) => {
-                    println!(
-                        "CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {:?}",
-                        value
-                    )
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS:{:?}, {}",
-                    e, e
-                ),
-            };
-        }
+        match device.max_num_sub_groups() {
+            Ok(value) => {
+                println!("CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_MAX_NUM_SUB_GROUPS: {:?}, {}", e, e),
+        };
+
+        match device.sub_group_independent_forward_progress() {
+            Ok(value) => {
+                println!(
+                    "CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {:?}",
+                    value
+                )
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS:{:?}, {}",
+                e, e
+            ),
+        };
 
         //////////////////////////////////////////////////////////////////////
         // CL_VERSION_3_0 parameters
-        #[cfg(feature = "CL_VERSION_3_0")]
-        {
-            match device.numeric_version() {
-                Ok(value) => {
-                    println!("CL_DEVICE_NUMERIC_VERSION: {:X}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_NUMERIC_VERSION: {:?}, {}", e, e),
-            };
 
-            match device.extensions_with_version() {
-                Ok(value) => {
-                    println!("CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.numeric_version() {
+            Ok(value) => {
+                println!("CL_DEVICE_NUMERIC_VERSION: {:X}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_NUMERIC_VERSION: {:?}, {}", e, e),
+        };
 
-            match device.ils_with_version() {
-                Ok(value) => {
-                    println!("CL_DEVICE_ILS_WITH_VERSION: {:?}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_ILS_WITH_VERSION: {:?}, {}", e, e),
-            };
+        match device.extensions_with_version() {
+            Ok(value) => {
+                println!("CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_EXTENSIONS_WITH_VERSION: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.built_in_kernels_with_version() {
-                Ok(value) => {
-                    println!("CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.ils_with_version() {
+            Ok(value) => {
+                println!("CL_DEVICE_ILS_WITH_VERSION: {:?}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_ILS_WITH_VERSION: {:?}, {}", e, e),
+        };
 
-            match device.atomic_memory_capabilities() {
-                Ok(value) => {
-                    println!("CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:X}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.built_in_kernels_with_version() {
+            Ok(value) => {
+                println!("CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_BUILT_IN_KERNELS_WITH_VERSION: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.atomic_fence_capabilities() {
-                Ok(value) => {
-                    println!("CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:X}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.atomic_memory_capabilities() {
+            Ok(value) => {
+                println!("CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:X}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_ATOMIC_MEMORY_CAPABILITIES: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.non_uniform_work_group_support() {
-                Ok(value) => {
-                    println!("CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.atomic_fence_capabilities() {
+            Ok(value) => {
+                println!("CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:X}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_ATOMIC_FENCE_CAPABILITIES: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.opencl_c_all_versions() {
-                Ok(value) => {
-                    println!("CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.non_uniform_work_group_support() {
+            Ok(value) => {
+                println!("CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_NON_UNIFORM_WORK_GROUP_SUPPORT: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.preferred_work_group_size_multiple() {
-                Ok(value) => {
-                    println!("CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.opencl_c_all_versions() {
+            Ok(value) => {
+                println!("CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_OPENCL_C_ALL_VERSIONS: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.work_group_collective_functions_support() {
-                Ok(value) => {
-                    println!(
-                        "CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {}",
-                        value
-                    )
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.preferred_work_group_size_multiple() {
+            Ok(value) => {
+                println!("CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.generic_address_space_support() {
-                Ok(value) => {
-                    println!("CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.work_group_collective_functions_support() {
+            Ok(value) => {
+                println!(
+                    "CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {}",
+                    value
+                )
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_WORK_GROUP_COLLECTIVE_FUNCTIONS_SUPPORT: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.uuid_khr() {
-                Ok(value) => {
-                    println!("CL_DEVICE_UUID_KHR: {:?}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_UUID_KHR: {:?}, {}", e, e),
-            };
+        match device.generic_address_space_support() {
+            Ok(value) => {
+                println!("CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_GENERIC_ADDRESS_SPACE_SUPPORT: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.driver_uuid_khr() {
-                Ok(value) => {
-                    println!("CL_DRIVER_UUID_KHR: {:?}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DRIVER_UUID_KHR: {:?}, {}", e, e),
-            };
+        match device.uuid_khr() {
+            Ok(value) => {
+                println!("CL_DEVICE_UUID_KHR: {:?}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_UUID_KHR: {:?}, {}", e, e),
+        };
 
-            match device.luid_valid_khr() {
-                Ok(value) => {
-                    println!("CL_DEVICE_LUID_VALID_KHR: {}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_LUID_VALID_KHR: {:?}, {}", e, e),
-            };
+        match device.driver_uuid_khr() {
+            Ok(value) => {
+                println!("CL_DRIVER_UUID_KHR: {:?}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DRIVER_UUID_KHR: {:?}, {}", e, e),
+        };
 
-            match device.luid_khr() {
-                Ok(value) => {
-                    println!("CL_DEVICE_LUID_KHR: {:?}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_LUID_KHR: {:?}, {}", e, e),
-            };
+        match device.luid_valid_khr() {
+            Ok(value) => {
+                println!("CL_DEVICE_LUID_VALID_KHR: {}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_LUID_VALID_KHR: {:?}, {}", e, e),
+        };
 
-            match device.node_mask_khr() {
-                Ok(value) => {
-                    println!("CL_DEVICE_NODE_MASK_KHR: {}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_NODE_MASK_KHR: {:?}, {}", e, e),
-            };
+        match device.luid_khr() {
+            Ok(value) => {
+                println!("CL_DEVICE_LUID_KHR: {:?}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_LUID_KHR: {:?}, {}", e, e),
+        };
 
-            match device.opencl_c_features() {
-                Ok(value) => {
-                    println!("CL_DEVICE_OPENCL_C_FEATURES: {:?}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_OPENCL_C_FEATURES: {:?}, {}", e, e),
-            };
+        match device.node_mask_khr() {
+            Ok(value) => {
+                println!("CL_DEVICE_NODE_MASK_KHR: {}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_NODE_MASK_KHR: {:?}, {}", e, e),
+        };
 
-            match device.device_enqueue_capabilities() {
-                Ok(value) => {
-                    println!("CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:X}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:?}, {}",
-                    e, e
-                ),
-            };
+        match device.opencl_c_features() {
+            Ok(value) => {
+                println!("CL_DEVICE_OPENCL_C_FEATURES: {:?}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_OPENCL_C_FEATURES: {:?}, {}", e, e),
+        };
 
-            match device.pipe_support() {
-                Ok(value) => {
-                    println!("CL_DEVICE_PIPE_SUPPORT: {}", value)
-                }
-                Err(e) => println!("OpenCL error, CL_DEVICE_PIPE_SUPPORT: {:?}, {}", e, e),
-            };
+        match device.device_enqueue_capabilities() {
+            Ok(value) => {
+                println!("CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:X}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_DEVICE_ENQUEUE_CAPABILITIES: {:?}, {}",
+                e, e
+            ),
+        };
 
-            match device.latest_conformance_version_passed() {
-                Ok(value) => {
-                    println!("CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}", value)
-                }
-                Err(e) => println!(
-                    "OpenCL error, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}, {}",
-                    e, e
-                ),
-            };
-        }
+        match device.pipe_support() {
+            Ok(value) => {
+                println!("CL_DEVICE_PIPE_SUPPORT: {}", value)
+            }
+            Err(e) => println!("OpenCL error, CL_DEVICE_PIPE_SUPPORT: {:?}, {}", e, e),
+        };
+
+        match device.latest_conformance_version_passed() {
+            Ok(value) => {
+                println!("CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}", value)
+            }
+            Err(e) => println!(
+                "OpenCL error, CL_DEVICE_LATEST_CONFORMANCE_VERSION_PASSED: {:?}, {}",
+                e, e
+            ),
+        };
 
         match device.integer_dot_product_capabilities_khr() {
             Ok(value) => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -238,7 +238,7 @@ mod tests {
         println!("event.profiling_command_end(): {}", value);
         assert!(0 < value);
 
-        // CL_VERSION_2_0
+        #[cfg(feature = "CL_VERSION_2_0")]
         match event.profiling_command_complete() {
             Ok(value) => println!("event.profiling_command_complete(): {}", value),
             Err(e) => println!("OpenCL error, event.profiling_command_complete(): {}", e),

--- a/src/event.rs
+++ b/src/event.rs
@@ -125,7 +125,7 @@ impl Event {
         )
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn profiling_command_complete(&self) -> Result<cl_ulong> {
         Ok(
             get_event_profiling_info(self.event, ProfilingInfo::CL_PROFILING_COMMAND_COMPLETE)?
@@ -238,7 +238,7 @@ mod tests {
         println!("event.profiling_command_end(): {}", value);
         assert!(0 < value);
 
-        #[cfg(feature = "CL_VERSION_2_0")]
+        // CL_VERSION_2_0
         match event.profiling_command_complete() {
             Ok(value) => println!("event.profiling_command_complete(): {}", value),
             Err(e) => println!("OpenCL error, event.profiling_command_complete(): {}", e),

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -21,10 +21,9 @@ use super::Result;
 
 #[allow(unused_imports)]
 use cl3::ext;
-use cl3::types::{
-    cl_context, cl_device_id, cl_event, cl_kernel, cl_kernel_exec_info, cl_program, cl_uint,
-    cl_ulong,
-};
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl3::types::cl_kernel_exec_info;
+use cl3::types::{cl_context, cl_device_id, cl_event, cl_kernel, cl_program, cl_uint, cl_ulong};
 use libc::{c_void, size_t};
 use std::ffi::CString;
 use std::mem;
@@ -120,6 +119,7 @@ impl Kernel {
     /// * `arg_ptr` - the SVM pointer to the data for the argument at arg_index.
     ///
     /// returns an empty Result or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn set_arg_svm_pointer(&self, arg_index: cl_uint, arg_ptr: *const c_void) -> Result<()> {
         Ok(set_kernel_arg_svm_pointer(self.kernel, arg_index, arg_ptr)?)
     }
@@ -131,6 +131,7 @@ impl Kernel {
     /// * `param_ptr` - pointer to the data for the param_name.
     ///
     /// returns an empty Result or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn set_exec_info<T>(
         &self,
         param_name: cl_kernel_exec_info,
@@ -168,6 +169,7 @@ impl Kernel {
         Ok(get_kernel_info(self.kernel, KernelInfo::CL_KERNEL_ATTRIBUTES)?.to_string())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn get_arg_address_qualifier(&self, arg_indx: cl_uint) -> Result<cl_uint> {
         Ok(get_kernel_arg_info(
             self.kernel,
@@ -177,6 +179,7 @@ impl Kernel {
         .to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn get_arg_access_qualifier(&self, arg_indx: cl_uint) -> Result<cl_uint> {
         Ok(get_kernel_arg_info(
             self.kernel,
@@ -186,6 +189,7 @@ impl Kernel {
         .to_uint())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn get_arg_type_qualifier(&self, arg_indx: cl_uint) -> Result<cl_ulong> {
         Ok(get_kernel_arg_info(
             self.kernel,
@@ -195,6 +199,7 @@ impl Kernel {
         .to_ulong())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn get_arg_type_name(&self, arg_indx: cl_uint) -> Result<String> {
         Ok(get_kernel_arg_info(
             self.kernel,
@@ -204,6 +209,7 @@ impl Kernel {
         .to_string())
     }
 
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn get_arg_name(&self, arg_indx: cl_uint) -> Result<String> {
         Ok(
             get_kernel_arg_info(self.kernel, arg_indx, KernelArgInfo::CL_KERNEL_ARG_NAME)?
@@ -390,6 +396,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `arg` - a reference to the data for the kernel argument.
     ///
     /// returns a reference to self.
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn set_arg_svm<'b, T>(&'b mut self, arg_ptr: *const T) -> &'b mut Self {
         assert!(
             self.arg_index < self.num_args,
@@ -410,6 +417,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `param_ptr` - pointer to the data for the param_name.
     ///
     /// returns a reference to self.
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn set_exec_info<'b, T>(
         &'b mut self,
         param_name: cl_kernel_exec_info,
@@ -692,36 +700,39 @@ mod tests {
         println!("kernel.attributes(): {}", value);
         // assert!(value.is_empty());
 
-        let arg0_address = kernels[0]
-            .get_arg_address_qualifier(0)
-            .expect("OpenCL kernel_0.get_arg_address_qualifier");
-        println!(
-            "OpenCL kernel_0.get_arg_address_qualifier: {:X}",
-            arg0_address
-        );
+        #[cfg(feature = "CL_VERSION_1_2")]
+        {
+            let arg0_address = kernels[0]
+                .get_arg_address_qualifier(0)
+                .expect("OpenCL kernel_0.get_arg_address_qualifier");
+            println!(
+                "OpenCL kernel_0.get_arg_address_qualifier: {:X}",
+                arg0_address
+            );
 
-        let arg0_access = kernels[0]
-            .get_arg_access_qualifier(0)
-            .expect("OpenCL kernel_0.get_arg_access_qualifier");
-        println!(
-            "OpenCL kernel_0.get_arg_access_qualifier: {:X}",
-            arg0_access
-        );
+            let arg0_access = kernels[0]
+                .get_arg_access_qualifier(0)
+                .expect("OpenCL kernel_0.get_arg_access_qualifier");
+            println!(
+                "OpenCL kernel_0.get_arg_access_qualifier: {:X}",
+                arg0_access
+            );
 
-        let arg0_type_name = kernels[0]
-            .get_arg_type_name(0)
-            .expect("OpenCL kernel_0.get_arg_type_name");
-        println!("OpenCL kernel_0.get_arg_type_name: {}", arg0_type_name);
+            let arg0_type_name = kernels[0]
+                .get_arg_type_name(0)
+                .expect("OpenCL kernel_0.get_arg_type_name");
+            println!("OpenCL kernel_0.get_arg_type_name: {}", arg0_type_name);
 
-        let arg0_type = kernels[0]
-            .get_arg_type_qualifier(0)
-            .expect("OpenCL kernel_0.get_arg_type_qualifier");
-        println!("OpenCL kernel_0.get_arg_type_qualifier: {}", arg0_type);
+            let arg0_type = kernels[0]
+                .get_arg_type_qualifier(0)
+                .expect("OpenCL kernel_0.get_arg_type_qualifier");
+            println!("OpenCL kernel_0.get_arg_type_qualifier: {}", arg0_type);
 
-        let arg0_name = kernels[0]
-            .get_arg_name(0)
-            .expect("OpenCL kernel_0.get_arg_name");
-        println!("OpenCL kernel_0.get_arg_name: {}", arg0_name);
+            let arg0_name = kernels[0]
+                .get_arg_name(0)
+                .expect("OpenCL kernel_0.get_arg_name");
+            println!("OpenCL kernel_0.get_arg_name: {}", arg0_name);
+        }
 
         let value = kernels[0].get_work_group_size(device.id()).unwrap();
         println!("kernel.get_work_group_size(): {}", value);

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -21,9 +21,11 @@ use super::Result;
 
 #[allow(unused_imports)]
 use cl3::ext;
-#[cfg(feature = "CL_VERSION_2_0")]
-use cl3::types::cl_kernel_exec_info;
-use cl3::types::{cl_context, cl_device_id, cl_event, cl_kernel, cl_program, cl_uint, cl_ulong};
+#[allow(unused_imports)]
+use cl3::types::{
+    cl_context, cl_device_id, cl_event, cl_kernel, cl_kernel_exec_info, cl_program, cl_uint,
+    cl_ulong,
+};
 use libc::{c_void, size_t};
 use std::ffi::CString;
 use std::mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ pub mod kernel;
 pub mod memory;
 pub mod platform;
 pub mod program;
+#[cfg(feature = "CL_VERSION_2_0")]
 pub mod svm;
 
 pub mod error_codes {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -322,6 +322,7 @@ impl Image {
     ///
     /// returns a Result containing the new OpenCL image object
     /// or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn create(
         context: &Context,
         flags: cl_mem_flags,
@@ -700,6 +701,7 @@ impl Sampler {
         Ok(Sampler::new(sampler))
     }
 
+    #[cfg(feature = "CL_VERSION_2_0")]
     pub fn create_with_properties(
         context: &Context,
         properties: *const cl_sampler_properties,
@@ -767,11 +769,13 @@ impl Sampler {
 /// Has methods to return information from calls to clGetPipeInfo with the
 /// appropriate parameters.  
 /// Implements the Drop trait to call release_mem_object when the object is dropped.
+#[cfg(feature = "CL_VERSION_2_0")]
 #[derive(Debug)]
 pub struct Pipe {
     pipe: cl_mem,
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 impl ClMem for Pipe {
     fn get(&self) -> cl_mem {
         self.pipe
@@ -782,12 +786,14 @@ impl ClMem for Pipe {
     }
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 impl Drop for Pipe {
     fn drop(&mut self) {
         memory::release_mem_object(self.get()).expect("Error: clReleaseMemObject");
     }
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 impl Pipe {
     pub fn new(pipe: cl_mem) -> Pipe {
         Pipe { pipe }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -103,7 +103,7 @@ pub trait ClMem {
         Ok(memory::get_mem_object_info(self.get(), MemInfo::CL_MEM_USES_SVM_POINTER)?.to_uint())
     }
 
-    // CL_VERSION_3_0
+    /// CL_VERSION_3_0
     fn properties(&self) -> Result<Vec<cl_ulong>> {
         Ok(memory::get_mem_object_info(self.get(), MemInfo::CL_MEM_PROPERTIES)?.to_vec_ulong())
     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -33,6 +33,7 @@ use cl3::ffi::cl_dx9_media_sharing::{
     cl_dx9_media_adapter_type_khr,
 };
 use cl3::platform;
+#[cfg(feature = "CL_VERSION_1_2")]
 use cl3::program;
 #[allow(unused_imports)]
 use cl3::types::{
@@ -219,6 +220,7 @@ impl Platform {
     }
 
     /// Unload an OpenCL compiler for a platform.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn unload_compiler(&self) -> Result<()> {
         Ok(program::unload_platform_compiler(self.id())?)
     }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -33,7 +33,7 @@ use cl3::ffi::cl_dx9_media_sharing::{
     cl_dx9_media_adapter_type_khr,
 };
 use cl3::platform;
-#[cfg(feature = "CL_VERSION_1_2")]
+#[allow(unused_imports)]
 use cl3::program;
 #[allow(unused_imports)]
 use cl3::types::{
@@ -189,7 +189,7 @@ impl Platform {
 
     /// The resolution of the host timer in nanoseconds as used by
     /// clGetDeviceAndHostTimer.  
-    // CL_VERSION_2_1
+    /// CL_VERSION_2_1
     pub fn host_timer_resolution(&self) -> Result<cl_ulong> {
         Ok(platform::get_platform_info(
             self.id(),
@@ -199,7 +199,7 @@ impl Platform {
     }
 
     /// The detailed (major, minor, patch) version supported by the platform.  
-    // CL_VERSION_3_0
+    /// CL_VERSION_3_0
     pub fn numeric_version(&self) -> Result<cl_version> {
         Ok(platform::get_platform_info(
             self.id(),
@@ -210,7 +210,7 @@ impl Platform {
 
     /// An array of description (name and version) structures that lists all the
     /// extensions supported by the platform.  
-    // CL_VERSION_3_0
+    /// CL_VERSION_3_0
     pub fn extensions_with_version(&self) -> Result<Vec<cl_name_version>> {
         Ok(platform::get_platform_info(
             self.id(),
@@ -220,6 +220,7 @@ impl Platform {
     }
 
     /// Unload an OpenCL compiler for a platform.
+    /// CL_VERSION_1_2
     #[cfg(feature = "CL_VERSION_1_2")]
     pub fn unload_compiler(&self) -> Result<()> {
         Ok(program::unload_platform_compiler(self.id())?)

--- a/src/program.rs
+++ b/src/program.rs
@@ -25,7 +25,9 @@ use cl3::ext;
 use cl3::types::{cl_context, cl_device_id, cl_int, cl_program, cl_uchar, cl_uint, CL_FALSE};
 #[allow(unused_imports)]
 use libc::{c_void, intptr_t, size_t};
-use std::ffi::{CStr, CString};
+#[cfg(feature = "CL_VERSION_1_2")]
+use std::ffi::CStr;
+use std::ffi::CString;
 use std::ptr;
 use std::result;
 
@@ -168,6 +170,7 @@ impl Program {
     ///
     /// returns a Result containing the new Program
     /// or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn create_from_builtin_kernels(
         context: &Context,
         devices: &[cl_device_id],
@@ -323,6 +326,7 @@ impl Program {
     ///
     /// returns a null Result
     /// or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn compile(
         &mut self,
         devices: &[cl_device_id],
@@ -352,6 +356,7 @@ impl Program {
     ///
     /// returns a null Result
     /// or the error code from the OpenCL C API function.
+    #[cfg(feature = "CL_VERSION_1_2")]
     pub fn link(
         &mut self,
         devices: &[cl_device_id],
@@ -615,7 +620,7 @@ mod tests {
         println!("program.get_build_binary_type(): {}", value);
         assert_eq!(CL_PROGRAM_BINARY_TYPE_EXECUTABLE as u32, value);
 
-        // CL_VERSION_2_0 value
+        #[cfg(feature = "CL_VERSION_2_0")]
         match program.get_build_global_variable_total_size(device.id()) {
             Ok(value) => println!("program.get_build_global_variable_total_size(): {}", value),
             Err(e) => println!(

--- a/src/program.rs
+++ b/src/program.rs
@@ -25,9 +25,8 @@ use cl3::ext;
 use cl3::types::{cl_context, cl_device_id, cl_int, cl_program, cl_uchar, cl_uint, CL_FALSE};
 #[allow(unused_imports)]
 use libc::{c_void, intptr_t, size_t};
-#[cfg(feature = "CL_VERSION_1_2")]
-use std::ffi::CStr;
-use std::ffi::CString;
+#[allow(unused_imports)]
+use std::ffi::{CStr, CString};
 use std::ptr;
 use std::result;
 
@@ -458,12 +457,12 @@ impl Program {
         Ok(get_program_info(self.program, ProgramInfo::CL_PROGRAM_KERNEL_NAMES)?.to_string())
     }
 
-    #[cfg(feature = "CL_VERSION_2_1")]
+    /// CL_VERSION_2_1
     pub fn get_program_il(&self) -> Result<String> {
         Ok(get_program_info(self.program, ProgramInfo::CL_PROGRAM_IL)?.to_string())
     }
 
-    #[cfg(feature = "CL_VERSION_2_2")]
+    /// CL_VERSION_2_2
     pub fn get_program_scope_global_ctors_present(&self) -> Result<bool> {
         Ok(get_program_info(
             self.program,
@@ -473,7 +472,7 @@ impl Program {
             != CL_FALSE)
     }
 
-    #[cfg(feature = "CL_VERSION_2_2")]
+    /// CL_VERSION_2_2
     pub fn get_program_scope_global_dtors_present(&self) -> Result<bool> {
         Ok(get_program_info(
             self.program,
@@ -517,7 +516,7 @@ impl Program {
         .to_uint())
     }
 
-    #[cfg(feature = "CL_VERSION_2_0")]
+    /// CL_VERSION_2_0
     pub fn get_build_global_variable_total_size(&self, device: cl_device_id) -> Result<size_t> {
         Ok(get_program_build_info(
             self.program,
@@ -620,7 +619,7 @@ mod tests {
         println!("program.get_build_binary_type(): {}", value);
         assert_eq!(CL_PROGRAM_BINARY_TYPE_EXECUTABLE as u32, value);
 
-        #[cfg(feature = "CL_VERSION_2_0")]
+        // CL_VERSION_2_0 value
         match program.get_build_global_variable_total_size(device.id()) {
             Ok(value) => println!("program.get_build_global_variable_total_size(): {}", value),
             Err(e) => println!(

--- a/src/svm.rs
+++ b/src/svm.rs
@@ -18,7 +18,9 @@ use cl3::device::{
     CL_DEVICE_SVM_COARSE_GRAIN_BUFFER, CL_DEVICE_SVM_FINE_GRAIN_BUFFER,
     CL_DEVICE_SVM_FINE_GRAIN_SYSTEM,
 };
-use cl3::memory::{svm_alloc, svm_free, CL_MEM_READ_WRITE, CL_MEM_SVM_FINE_GRAIN_BUFFER};
+use cl3::memory::CL_MEM_READ_WRITE;
+#[cfg(feature = "CL_VERSION_2_0")]
+use cl3::memory::{svm_alloc, svm_free, CL_MEM_SVM_FINE_GRAIN_BUFFER};
 use cl3::types::{cl_device_svm_capabilities, cl_svm_mem_flags, cl_uint};
 use libc::c_void;
 use std::fmt;

--- a/src/svm.rs
+++ b/src/svm.rs
@@ -18,9 +18,7 @@ use cl3::device::{
     CL_DEVICE_SVM_COARSE_GRAIN_BUFFER, CL_DEVICE_SVM_FINE_GRAIN_BUFFER,
     CL_DEVICE_SVM_FINE_GRAIN_SYSTEM,
 };
-use cl3::memory::CL_MEM_READ_WRITE;
-#[cfg(feature = "CL_VERSION_2_0")]
-use cl3::memory::{svm_alloc, svm_free, CL_MEM_SVM_FINE_GRAIN_BUFFER};
+use cl3::memory::{svm_alloc, svm_free, CL_MEM_READ_WRITE, CL_MEM_SVM_FINE_GRAIN_BUFFER};
 use cl3::types::{cl_device_svm_capabilities, cl_svm_mem_flags, cl_uint};
 use libc::c_void;
 use std::fmt;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,21 +14,15 @@
 
 extern crate opencl3;
 
-use cl3::device::{
-    CL_DEVICE_SVM_COARSE_GRAIN_BUFFER, CL_DEVICE_SVM_FINE_GRAIN_BUFFER, CL_DEVICE_TYPE_GPU,
-};
-use opencl3::command_queue::{
-    CommandQueue, CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE, CL_QUEUE_PROFILING_ENABLE,
-};
+use cl3::device::CL_DEVICE_TYPE_GPU;
+use opencl3::command_queue::{CommandQueue, CL_QUEUE_PROFILING_ENABLE};
 use opencl3::context::Context;
 use opencl3::device::Device;
-use opencl3::event;
 use opencl3::kernel::{ExecuteKernel, Kernel};
-use opencl3::memory::{Buffer, CL_MAP_READ, CL_MAP_WRITE, CL_MEM_READ_ONLY, CL_MEM_WRITE_ONLY};
+use opencl3::memory::{Buffer, CL_MEM_READ_ONLY, CL_MEM_WRITE_ONLY};
 use opencl3::platform::get_platforms;
 use opencl3::program::Program;
-use opencl3::svm::SvmVec;
-use opencl3::types::{cl_event, cl_float, CL_NON_BLOCKING, CL_BLOCKING};
+use opencl3::types::{cl_event, cl_float, CL_BLOCKING, CL_NON_BLOCKING};
 use std::ptr;
 
 const PROGRAM_SOURCE: &str = r#"
@@ -160,9 +154,16 @@ fn test_opencl_1_2_example() {
     println!("kernel execution duration (ns): {}", duration);
 }
 
+#[cfg(feature = "CL_VERSION_2_0")]
 #[test]
 #[ignore]
 fn test_opencl_svm_example() {
+    use cl3::device::{CL_DEVICE_SVM_COARSE_GRAIN_BUFFER, CL_DEVICE_SVM_FINE_GRAIN_BUFFER};
+    use opencl3::command_queue::CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE;
+    use opencl3::event;
+    use opencl3::memory::{CL_MAP_READ, CL_MAP_WRITE};
+    use opencl3::svm::SvmVec;
+
     let platforms = get_platforms().unwrap();
     assert!(0 < platforms.len());
 

--- a/tests/opencl2_kernel_test.rs
+++ b/tests/opencl2_kernel_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg(feature = "CL_VERSION_2_0")]
+
 extern crate opencl3;
 
 use cl3::device::{CL_DEVICE_SVM_FINE_GRAIN_BUFFER, CL_DEVICE_TYPE_GPU};


### PR DESCRIPTION
`openccl3` specifies compile time features for the different OpenCL versions,
but they weren't fully implemented. This PR implements them. The functions
become the `CL_VERSION_*` number when they were introduced. So if you e.g.
want to use OpenCL 1.2 and 2.0 features, you would need to specify the
`CL_VERSION_1_2` and `CL_VERSION_2_0`. All features prior to OpenCL 1.2
are always enabled.

This commit enables you to compile a `opencl3` version with only OpenCL 1.2
features (without any from newer version), which would then run on platforms
that only support OpenCL 1.2 (like MacOS).

Trying out if it can actually built with OpenCL 1.2 features only can be done with:

    cargo build --no-default-features --features CL_VERSION_1_2 --all-targets

It was manually tested that compiling with each `CL_VERSION_*` feature
individually, while disabling the other ones, works.

Fixes #30.