### PR TITLE
Introduce track_caller for panicing methods of ExecuteKernel

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -347,6 +347,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `arg` - a reference to the data for the kernel argument.
     ///
     /// returns a reference to self.
+    #[track_caller]
     pub fn set_arg<'b, T>(&'b mut self, arg: &T) -> &'b mut Self {
         assert!(
             self.arg_index < self.num_args,
@@ -373,6 +374,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `size` - the size of the local memory buffer in bytes.
     ///
     /// returns a reference to self.
+    #[track_caller]
     pub fn set_arg_local_buffer(&mut self, size: size_t) -> &mut Self {
         assert!(
             self.arg_index < self.num_args,
@@ -401,6 +403,7 @@ impl<'a> ExecuteKernel<'a> {
     ///
     /// returns a reference to self.
     #[cfg(feature = "CL_VERSION_2_0")]
+    #[track_caller]
     pub fn set_arg_svm<T>(&mut self, arg_ptr: *const T) -> &mut Self {
         assert!(
             self.arg_index < self.num_args,


### PR DESCRIPTION
This adds track_caller attributes to improve debugging for library users, as suggested in #49.

I did test it in my own project, worked as expected, for both the panic! and also the assert! calls.

* https://doc.rust-lang.org/stable/reference/attributes/codegen.html?highlight=track_call#the-track_caller-attribute
* for future reference, if any path in the library panics all that needs to be done for the panic to show the location in the users code is mark all functions along the call-stack with track_caller
* I did try and test the behavior, (with unit-tests) because I can be masocistic like that, but decided to give up on it, I would have to manually temporarily switch the panic_hook during testing, if that even works. Ugly, and if it happens to work its not guaranteed to continue working.