### PR TITLE
added sync for all threadsafe opencl objects

### DIFF
--- a/src/command_buffer.rs
+++ b/src/command_buffer.rs
@@ -62,6 +62,7 @@ impl Drop for CommandBuffer {
 }
 
 unsafe impl Send for CommandBuffer {}
+unsafe impl Sync for CommandBuffer {}
 
 impl CommandBuffer {
     fn new(buffer: cl_command_buffer_khr) -> CommandBuffer {

--- a/src/command_queue.rs
+++ b/src/command_queue.rs
@@ -67,6 +67,7 @@ impl Drop for CommandQueue {
 }
 
 unsafe impl Send for CommandQueue {}
+unsafe impl Sync for CommandQueue {}
 
 impl CommandQueue {
     fn new(queue: cl_command_queue, max_work_item_dimensions: cl_uint) -> CommandQueue {

--- a/src/context.rs
+++ b/src/context.rs
@@ -103,6 +103,7 @@ impl Drop for Context {
 }
 
 unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
 
 impl Context {
     fn new(context: cl_context, devices: &[cl_device_id]) -> Context {

--- a/src/device.rs
+++ b/src/device.rs
@@ -98,6 +98,9 @@ impl Drop for SubDevice {
 unsafe impl Send for SubDevice {}
 
 #[cfg(feature = "CL_VERSION_1_2")]
+unsafe impl Sync for SubDevice {}
+
+#[cfg(feature = "CL_VERSION_1_2")]
 impl SubDevice {
     pub fn new(id: cl_device_id) -> SubDevice {
         SubDevice { id }

--- a/src/event.rs
+++ b/src/event.rs
@@ -49,6 +49,7 @@ impl Drop for Event {
 }
 
 unsafe impl Send for Event {}
+unsafe impl Sync for Event {}
 
 impl Event {
     /// Create an Event from an OpenCL cl_event.

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -143,6 +143,7 @@ impl<T> Drop for Buffer<T> {
 }
 
 unsafe impl<T: Send> Send for Buffer<T> {}
+unsafe impl<T: Sync> Sync for Buffer<T> {}
 
 impl<T> Buffer<T> {
     pub fn new(buffer: cl_mem) -> Buffer<T> {

--- a/src/program.rs
+++ b/src/program.rs
@@ -99,6 +99,9 @@ impl Drop for Program {
     }
 }
 
+unsafe impl Send for Program {}
+unsafe impl Sync for Program {}
+
 impl Program {
     fn new(program: cl_program, kernel_names: &str) -> Program {
         Program {

--- a/src/svm.rs
+++ b/src/svm.rs
@@ -49,6 +49,7 @@ struct SvmRawVec<'a, T> {
 }
 
 unsafe impl<'a, T: Send> Send for SvmRawVec<'a, T> {}
+unsafe impl<'a, T: Sync> Sync for SvmRawVec<'a, T> {}
 
 impl<'a, T> SvmRawVec<'a, T> {
     fn new(context: &'a Context, svm_capabilities: cl_device_svm_capabilities) -> Self {


### PR DESCRIPTION
All opencl objects except cl_kernel are guaranteed to be threadsafe. Adds Sync to all of them so that opencl objects can be shared by threads.