### PR TITLE
Improved builder pattern for ExecuteKernel's set_arg, set_arg_local_buffer, set_global_work_offsets, ...

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -468,10 +468,11 @@ impl<'a> ExecuteKernel<'a> {
     /// This function is unsafe because name and ptr must be valid.
     #[cfg(feature = "CL_VERSION_2_0")]
     pub unsafe fn set_exec_info<T>(
-        &mut self,
+        #[allow(unused_mut)]
+        mut self, // mut for safety
         param_name: cl_kernel_exec_info,
         param_ptr: *const T,
-    ) -> &mut Self {
+    ) -> Self {
         self.kernel.set_exec_info(param_name, param_ptr).unwrap();
         self
     }
@@ -481,7 +482,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `size` - the size of the global work offset.
     ///
     /// returns a reference to self.
-    pub fn set_global_work_offset(&mut self, size: size_t) -> &mut Self {
+    pub fn set_global_work_offset(mut self, size: size_t) -> Self {
         self.global_work_offsets.push(size);
         self
     }
@@ -495,7 +496,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `sizes` - the sizes of the global work offset.
     ///
     /// returns a reference to self.
-    pub fn set_global_work_offsets(&mut self, sizes: &[size_t]) -> &mut Self {
+    pub fn set_global_work_offsets(mut self, sizes: &[size_t]) -> Self {
         assert!(
             self.global_work_offsets.is_empty(),
             "ExecuteKernel::set_global_work_offsets already set"
@@ -510,7 +511,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `size` - the size of the global work size.
     ///
     /// returns a reference to self.
-    pub fn set_global_work_size(&mut self, size: size_t) -> &mut Self {
+    pub fn set_global_work_size(mut self, size: size_t) -> Self {
         self.global_work_sizes.push(size);
         self
     }
@@ -524,7 +525,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `sizes` - the sizes of the global work sizes.
     ///
     /// returns a reference to self.
-    pub fn set_global_work_sizes<'b>(&'b mut self, sizes: &[size_t]) -> &'b mut Self {
+    pub fn set_global_work_sizes(mut self, sizes: &[size_t]) -> Self {
         assert!(
             self.global_work_sizes.is_empty(),
             "ExecuteKernel::global_work_sizes already set"
@@ -539,7 +540,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `size` - the size of the local work size.
     ///
     /// returns a reference to self.
-    pub fn set_local_work_size(&mut self, size: size_t) -> &mut Self {
+    pub fn set_local_work_size(mut self, size: size_t) -> Self {
         self.local_work_sizes.push(size);
         self
     }
@@ -553,7 +554,7 @@ impl<'a> ExecuteKernel<'a> {
     /// * `sizes` - the sizes of the local work sizes.
     ///
     /// returns a reference to self.
-    pub fn set_local_work_sizes<'b>(&'b mut self, sizes: &[size_t]) -> &'b mut Self {
+    pub fn set_local_work_sizes(mut self, sizes: &[size_t]) -> Self {
         assert!(
             self.local_work_sizes.is_empty(),
             "ExecuteKernel::local_work_sizes already set"

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -372,7 +372,7 @@ impl<'a> ExecuteKernel<'a> {
     ///
     /// This function is unsafe because arg must be valid.
     #[track_caller]
-    pub unsafe fn set_arg<'b, T>(&'b mut self, arg: &T) -> &'b mut Self {
+    pub unsafe fn set_arg<T>(mut self, arg: &T) -> Self {
         assert!(
             self.arg_index < self.num_args,
             "ExecuteKernel::set_arg too many args"
@@ -403,7 +403,7 @@ impl<'a> ExecuteKernel<'a> {
     ///
     /// This function is unsafe because size must be valid.
     #[track_caller]
-    pub unsafe fn set_arg_local_buffer(&mut self, size: size_t) -> &mut Self {
+    pub unsafe fn set_arg_local_buffer(mut self, size: size_t) -> Self {
         assert!(
             self.arg_index < self.num_args,
             "ExecuteKernel::set_arg_local_buffer too many args"
@@ -436,7 +436,7 @@ impl<'a> ExecuteKernel<'a> {
     /// This function is unsafe because ptr must be valid.
     #[cfg(feature = "CL_VERSION_2_0")]
     #[track_caller]
-    pub unsafe fn set_arg_svm<T>(&mut self, arg_ptr: *const T) -> &mut Self {
+    pub unsafe fn set_arg_svm<T>(mut self, arg_ptr: *const T) -> Self {
         assert!(
             self.arg_index < self.num_args,
             "ExecuteKernel::set_arg_svm too many args"


### PR DESCRIPTION
## What has been done?

I have, as stated in the title, made use of better Rust syntax for the builder pattern methods of ExecuteKernel to give them more flexibility if necessary (needed in my case).

## Usage example

As an example take the following code:

```rust
let mut execute_kernel = ExecuteKernek::new(kernel) // values gets dropped while being used
  .set_arg(...); // temporary value is freed after this statement

if condition {
    execute_kernel = execute_kernel.set_arg(...); // borrow later used here
} else {
   execute_kernel = execute_kernel.set_arg(...); // borrow later used here
}
```

What happens in this example is that it will fail as stated by my comments. To get over this, instead of borrowing ExecuteKernel, actually taking ownership of it, since it can be done in implementation methods. Once this is done that exampĺe can actually work instead of breaking because with taking ownership there will be no borrows.

## How was it done?

I did this by basically just taking the classic Rust syntax `&` from each of the methods that made up a builder pattern for the ExecuteKernel struct, and then removing these borrows from the return types of these methods. This results in owned returns and owned methods.