### PR TITLE
fix static linking by disabling default features in cl3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ default = ["dynamic"]
 
 [dependencies]
 libc = "0.2"
-cl3 = "0.13"
+cl3 = { version = "0.13", default-features = false }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
By default, the `opencl3` crate activates the `dynamic` feature flag of the `cl3` crate, which overrides the `static` flag. This means that it's impossible to do static linking with `opencl3`.

This patch adds `default-features = true` to the `cl3` dep entry, which disables the `dynamic` flag unless the `opencl3` crate's `dynamic` flag is turned on.